### PR TITLE
chore: update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/user-attachments/assets/b250bf2b-e61c-4a6d-9872-6d3dcb3339e6
 
 # ⬇️ Install
 
-- Download from [here](https://github.com/kaleidot725/AdbPad/releases/tag/v1.5.0).
+- Download from [here](https://github.com/kaleidot725/AdbPad/releases/tag/v1.5.1).
 - Setup adb path on Setting.
 
 https://github.com/user-attachments/assets/f5542ace-118d-4165-a138-49d59c7bda8b

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "jp.kaleidot725"
-version = "1.5.0"
+version = "1.5.1"
 
 kotlin {
     jvm()

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -1,6 +1,6 @@
 package jp.kaleidot725.adbpad.domain.model.language.resources
 
-val APP_VERSION = "v1.5.0"
+val APP_VERSION = "v1.5.1"
 
 interface StringResources {
     val windowTitle: String


### PR DESCRIPTION
This pull request includes updates to the version number in the `README.md` file and the `StringResources.kt` file to reflect the new release version 1.5.1.

Version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the download link to point to version 1.5.1.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt`](diffhunk://#diff-c176a2a6de40c297218931afa52676182df0f30d505dec87a61767159bfe0ecbL3-R3): Updated the `APP_VERSION` constant to "v1.5.1".