### PR TITLE
feat: fix command menu filter

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommand.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommand.kt
@@ -110,28 +110,28 @@ interface NormalCommand {
         override val title: String get() = Language.commandWifiOnTitle
         override val details: String get() = Language.commandWifiOnDetails
         override val requests: List<ShellCommandRequest> = listOf(ShellCommandRequest("svc wifi enable"))
-        override val category: NormalCommandCategory = NormalCommandCategory.Communication
+        override val category: NormalCommandCategory = NormalCommandCategory.COM
     }
 
     data class WifiOff(override val isRunning: Boolean = false) : NormalCommand {
         override val title: String get() = Language.commandWifiOffTitle
         override val details: String get() = Language.commandWifiOffDetails
         override val requests: List<ShellCommandRequest> = listOf(ShellCommandRequest("svc wifi disable"))
-        override val category: NormalCommandCategory = NormalCommandCategory.Communication
+        override val category: NormalCommandCategory = NormalCommandCategory.COM
     }
 
     data class DataOn(override val isRunning: Boolean = false) : NormalCommand {
         override val title: String get() = Language.commandDataOnTitle
         override val details: String get() = Language.commandDataOnDetails
         override val requests: List<ShellCommandRequest> = listOf(ShellCommandRequest("svc data enable"))
-        override val category: NormalCommandCategory = NormalCommandCategory.Communication
+        override val category: NormalCommandCategory = NormalCommandCategory.COM
     }
 
     data class DataOff(override val isRunning: Boolean = false) : NormalCommand {
         override val title: String get() = Language.commandDataOffTitle
         override val details: String get() = Language.commandDataOffDetails
         override val requests: List<ShellCommandRequest> = listOf(ShellCommandRequest("svc data disable"))
-        override val category: NormalCommandCategory = NormalCommandCategory.Communication
+        override val category: NormalCommandCategory = NormalCommandCategory.COM
     }
 
     data class WifiAndDataOn(override val isRunning: Boolean = false) : NormalCommand {
@@ -142,7 +142,7 @@ interface NormalCommand {
                 ShellCommandRequest("svc wifi enable"),
                 ShellCommandRequest("svc data enable"),
             )
-        override val category: NormalCommandCategory = NormalCommandCategory.Communication
+        override val category: NormalCommandCategory = NormalCommandCategory.COM
     }
 
     data class WifiAndDataOff(override val isRunning: Boolean = false) : NormalCommand {
@@ -153,7 +153,7 @@ interface NormalCommand {
                 ShellCommandRequest("svc wifi disable"),
                 ShellCommandRequest("svc data disable"),
             )
-        override val category: NormalCommandCategory = NormalCommandCategory.Communication
+        override val category: NormalCommandCategory = NormalCommandCategory.COM
     }
 
     data class ScreenPinningOff(override val isRunning: Boolean = false) : NormalCommand {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommandCategory.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommandCategory.kt
@@ -2,5 +2,5 @@ package jp.kaleidot725.adbpad.domain.model.command
 
 enum class NormalCommandCategory {
     UI,
-    Communication,
+    COM,
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/command/GetNormalCommandGroup.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/command/GetNormalCommandGroup.kt
@@ -12,7 +12,7 @@ class GetNormalCommandGroup(
         return NormalCommandGroup(
             all = all,
             ui = all.filter { it.category == NormalCommandCategory.UI },
-            communication = all.filter { it.category == NormalCommandCategory.Communication },
+            communication = all.filter { it.category == NormalCommandCategory.COM },
         )
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/Color.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/Color.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.unit.dp
@@ -31,12 +33,13 @@ fun Modifier.selectedBackground(isSelected: Boolean): Modifier {
 fun Modifier.clickableBackground(
     isSelected: Boolean = false,
     selectedColor: Color = MaterialTheme.colors.primary.copy(alpha = 0.2f),
+    shape: Shape = RectangleShape,
     isDarker: Boolean = false,
 ): Modifier {
     var isMouseOver by remember { mutableStateOf(false) }
     val one =
         if (isSelected) {
-            this.background(color = selectedColor)
+            this.background(color = selectedColor, shape = shape)
         } else if (isMouseOver) {
             this.background(
                 color =
@@ -47,6 +50,7 @@ fun Modifier.clickableBackground(
                     } else {
                         Color.White.copy(alpha = 0.1f)
                     },
+                shape = shape,
             )
         } else {
             this

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
@@ -25,13 +25,13 @@ fun CommandScreen(
         CommandTab(
             filtered = filtered,
             onClick = onClickFilter,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(8.dp),
         )
         CommandList(
             commands =
                 when (filtered) {
                     NormalCommandCategory.UI -> commands.ui
-                    NormalCommandCategory.Communication -> commands.communication
+                    NormalCommandCategory.COM -> commands.communication
                     null -> commands.all
                 },
             canExecute = canExecute,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
@@ -1,9 +1,15 @@
 package jp.kaleidot725.adbpad.ui.screen.command.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Diamond
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.View
+import com.composables.icons.lucide.Wifi
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 
 @Composable
@@ -12,23 +18,29 @@ fun CommandTab(
     filtered: NormalCommandCategory?,
     onClick: (NormalCommandCategory?) -> Unit,
 ) {
-    Row(modifier) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
         CommandTabItem(
             title = "All",
+            icon = Lucide.Diamond,
             isSelected = filtered == null,
             onClick = { onClick(null) },
         )
 
         CommandTabItem(
             title = NormalCommandCategory.UI.toString(),
+            icon = Lucide.View,
             isSelected = filtered == NormalCommandCategory.UI,
             onClick = { onClick(NormalCommandCategory.UI) },
         )
 
         CommandTabItem(
-            title = NormalCommandCategory.Communication.toString(),
-            isSelected = filtered == NormalCommandCategory.Communication,
-            onClick = { onClick(NormalCommandCategory.Communication) },
+            title = NormalCommandCategory.COM.toString(),
+            icon = Lucide.Wifi,
+            isSelected = filtered == NormalCommandCategory.COM,
+            onClick = { onClick(NormalCommandCategory.COM) },
         )
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
@@ -20,7 +20,7 @@ fun CommandTab(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         CommandTabItem(
             title = "All",

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt
@@ -41,7 +41,7 @@ fun CommandTabItem(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            modifier = Modifier.align(Alignment.CenterStart).padding(start = 12.dp, top = 4.dp)
+            modifier = Modifier.align(Alignment.CenterStart).padding(start = 12.dp, top = 4.dp),
         )
         Text(
             text = title,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt
@@ -1,19 +1,23 @@
 package jp.kaleidot725.adbpad.ui.screen.command.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Preview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
@@ -21,6 +25,7 @@ import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
 @Composable
 fun CommandTabItem(
     title: String,
+    icon: ImageVector,
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -29,28 +34,21 @@ fun CommandTabItem(
         modifier
             .widthIn(min = 200.dp)
             .heightIn(min = 40.dp)
-            .clickableBackground(
-                isSelected = isSelected,
-                selectedColor = Color.Transparent,
-            )
+            .clickableBackground(isSelected = isSelected, shape = RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(8.dp))
             .clickable(onClick = onClick),
     ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.align(Alignment.CenterStart).padding(start = 12.dp, top = 4.dp)
+        )
         Text(
             text = title,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.subtitle1,
             modifier = Modifier.align(Alignment.Center),
         )
-        if (isSelected) {
-            Box(
-                modifier =
-                    Modifier
-                        .height(2.dp)
-                        .widthIn(200.dp)
-                        .background(MaterialTheme.colors.primary)
-                        .align(Alignment.BottomEnd),
-            )
-        }
     }
 }
 
@@ -58,7 +56,7 @@ fun CommandTabItem(
 @Composable
 private fun CommandTabItemPreview() {
     Row {
-        CommandTabItem("one", false, {})
-        CommandTabItem("two", true, {})
+        CommandTabItem("one", Icons.Default.Preview, false, {})
+        CommandTabItem("two", Icons.Default.Preview, true, {})
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `NormalCommand` and `NormalCommandCategory` classes, as well as updates to the UI components to improve the user interface and code consistency. The most important changes include renaming the `Communication` category to `COM`, adding icons to command tabs, and updating background shapes in the UI.

### Changes to Command Categories:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommand.kt`](diffhunk://#diff-196cc87c946563ac63c6eb920376025a3049ca14bd44df7e871dcdae99e66e99L113-R134): Changed `NormalCommandCategory.Communication` to `NormalCommandCategory.COM` for multiple commands. [[1]](diffhunk://#diff-196cc87c946563ac63c6eb920376025a3049ca14bd44df7e871dcdae99e66e99L113-R134) [[2]](diffhunk://#diff-196cc87c946563ac63c6eb920376025a3049ca14bd44df7e871dcdae99e66e99L145-R145) [[3]](diffhunk://#diff-196cc87c946563ac63c6eb920376025a3049ca14bd44df7e871dcdae99e66e99L156-R156)
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommandCategory.kt`](diffhunk://#diff-76b0ed99d450fb052ae5b9a7aeaced9a55b57b1b56853b2a5740ec3f463f779dL5-R5): Renamed `Communication` to `COM` in the `NormalCommandCategory` enum.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/command/GetNormalCommandGroup.kt`](diffhunk://#diff-9112143269bfbba25a457c5b1d7e8d2bc7854e8b4d9012fe39f4ccecb355e687L15-R15): Updated filter logic to use `NormalCommandCategory.COM` instead of `NormalCommandCategory.Communication`.

### UI Improvements:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt`](diffhunk://#diff-15b7a36bb810457a4640087e0a82d67ed0103befe4ae35c59eb4db8824a19745L28-R34): Modified padding for `CommandTab` and updated category filter to use `NormalCommandCategory.COM`.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt`](diffhunk://#diff-b99988eb96d4f740992060911a578aeab7b543e7934b0cf8ff5a3844e8ff81d5R4-R12): Added icons to command tabs and arranged them with spacing. [[1]](diffhunk://#diff-b99988eb96d4f740992060911a578aeab7b543e7934b0cf8ff5a3844e8ff81d5R4-R12) [[2]](diffhunk://#diff-b99988eb96d4f740992060911a578aeab7b543e7934b0cf8ff5a3844e8ff81d5L15-R43)
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt`](diffhunk://#diff-919693bd37d4ba49e6f588dd1e1820833ab2a3e679f649000ff48d87ed56930dL4-R28): Updated `CommandTabItem` to include icons and improved background shape handling. [[1]](diffhunk://#diff-919693bd37d4ba49e6f588dd1e1820833ab2a3e679f649000ff48d87ed56930dL4-R28) [[2]](diffhunk://#diff-919693bd37d4ba49e6f588dd1e1820833ab2a3e679f649000ff48d87ed56930dL32-R60)

### Code Enhancements:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/Color.kt`](diffhunk://#diff-450e508ff94d75c8dc074bf9bb88d497b581ff8b0d23121e399c8dce1631dc0eR15-R16): Added `RectangleShape` and `Shape` imports, and updated `clickableBackground` method to accept a shape parameter. [[1]](diffhunk://#diff-450e508ff94d75c8dc074bf9bb88d497b581ff8b0d23121e399c8dce1631dc0eR15-R16) [[2]](diffhunk://#diff-450e508ff94d75c8dc074bf9bb88d497b581ff8b0d23121e399c8dce1631dc0eR36-R42) [[3]](diffhunk://#diff-450e508ff94d75c8dc074bf9bb88d497b581ff8b0d23121e399c8dce1631dc0eR53)

![image](https://github.com/user-attachments/assets/e329a388-ba75-4750-9115-c295ee034c66)
