### PR TITLE
feat: change text fields type

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt
@@ -2,6 +2,7 @@ package jp.kaleidot725.adbpad.ui.screen.setting.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
@@ -14,7 +15,7 @@ fun SettingField(
     isError: Boolean,
     onValueChange: (String) -> Unit,
 ) {
-    TextField(
+    OutlinedTextField(
         value = input,
         onValueChange = onValueChange,
         label = { Text(title) },


### PR DESCRIPTION
This pull request includes changes to the `SettingField` component in the `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt` file. The most important changes involve switching from using `TextField` to `OutlinedTextField` for better UI consistency.

Changes to `SettingField` component:

* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt`](diffhunk://#diff-e5397fd0d5504417965b8c6807204efcbd820aa48be2bd9d64281f2aa0754772R5): Imported `OutlinedTextField` from `androidx.compose.material`.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt`](diffhunk://#diff-e5397fd0d5504417965b8c6807204efcbd820aa48be2bd9d64281f2aa0754772L17-R18): Replaced `TextField` with `OutlinedTextField` in the `SettingField` composable function.

![スクリーンショット 2025-02-16 13 16 45](https://github.com/user-attachments/assets/1e9097c3-c52e-4db8-a804-3f7faebe7a1e)
