### PR TITLE
fix: bugfix command category

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommandCategory.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommandCategory.kt
@@ -1,6 +1,7 @@
 package jp.kaleidot725.adbpad.domain.model.command
 
 enum class NormalCommandCategory {
+    ALL,
     UI,
     COM,
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
@@ -16,8 +16,8 @@ import jp.kaleidot725.adbpad.ui.screen.command.component.CommandTab
 @Composable
 fun CommandScreen(
     commands: NormalCommandGroup,
-    filtered: NormalCommandCategory?,
-    onClickFilter: (NormalCommandCategory?) -> Unit,
+    filtered: NormalCommandCategory,
+    onClickFilter: (NormalCommandCategory) -> Unit,
     canExecute: Boolean,
     onExecute: (NormalCommand) -> Unit,
 ) {
@@ -32,7 +32,7 @@ fun CommandScreen(
                 when (filtered) {
                     NormalCommandCategory.UI -> commands.ui
                     NormalCommandCategory.COM -> commands.communication
-                    null -> commands.all
+                    NormalCommandCategory.ALL -> commands.all
                 },
             canExecute = canExecute,
             onExecute = onExecute,
@@ -51,7 +51,7 @@ private fun CommandScreen_Preview() {
                 listOf(NormalCommand.DarkThemeOn(), NormalCommand.DarkThemeOff()),
                 listOf(NormalCommand.WifiOn()),
             ),
-        filtered = null,
+        filtered = NormalCommandCategory.ALL,
         onClickFilter = {},
         canExecute = true,
         onExecute = {},

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandState.kt
@@ -6,7 +6,7 @@ import jp.kaleidot725.adbpad.domain.model.device.Device
 
 data class CommandState(
     val commands: NormalCommandGroup = NormalCommandGroup.Empty,
-    val filtered: NormalCommandCategory? = null,
+    val filtered: NormalCommandCategory = NormalCommandCategory.ALL,
     val selectedDevice: Device? = null,
 ) {
     val canExecuteCommand: Boolean get() = selectedDevice != null

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
@@ -26,7 +26,7 @@ class CommandStateHolder(
 ) : ChildStateHolder<CommandState> {
     private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main + Dispatchers.IO)
     private val commands: MutableStateFlow<NormalCommandGroup> = MutableStateFlow(NormalCommandGroup.Empty)
-    private val filtered: MutableStateFlow<NormalCommandCategory?> = MutableStateFlow(null)
+    private val filtered: MutableStateFlow<NormalCommandCategory> = MutableStateFlow(NormalCommandCategory.ALL)
     private val selectedDevice: StateFlow<Device?> =
         getSelectedDeviceFlowUseCase()
             .stateIn(coroutineScope, SharingStarted.WhileSubscribed(), null)
@@ -65,7 +65,7 @@ class CommandStateHolder(
         }
     }
 
-    fun clickTab(filtered: NormalCommandCategory?) {
+    fun clickTab(filtered: NormalCommandCategory) {
         this.filtered.value = filtered
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
@@ -15,18 +15,18 @@ import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 @Composable
 fun CommandTab(
     modifier: Modifier = Modifier,
-    filtered: NormalCommandCategory?,
-    onClick: (NormalCommandCategory?) -> Unit,
+    filtered: NormalCommandCategory,
+    onClick: (NormalCommandCategory) -> Unit,
 ) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         CommandTabItem(
-            title = "All",
+            title = NormalCommandCategory.ALL.toString(),
             icon = Lucide.Diamond,
-            isSelected = filtered == null,
-            onClick = { onClick(null) },
+            isSelected = filtered == NormalCommandCategory.ALL,
+            onClick = { onClick(NormalCommandCategory.ALL) },
         )
 
         CommandTabItem(
@@ -48,5 +48,5 @@ fun CommandTab(
 @Preview
 @Composable
 private fun CommandTabPreview() {
-    CommandTab(filtered = null) {}
+    CommandTab(filtered = NormalCommandCategory.ALL) {}
 }


### PR DESCRIPTION
This pull request introduces a new `ALL` category to the `NormalCommandCategory` enum and updates the codebase to use this new category instead of `null` for filtering commands. The most important changes include modifying the `CommandScreen`, `CommandState`, and `CommandTab` components to accommodate this new category.

### Enum Update:
* Added `ALL` to the `NormalCommandCategory` enum in `NormalCommandCategory.kt`.

### Command Screen Updates:
* Changed the `filtered` parameter in `CommandScreen` to use `NormalCommandCategory.ALL` instead of `null`. [[1]](diffhunk://#diff-15b7a36bb810457a4640087e0a82d67ed0103befe4ae35c59eb4db8824a19745L19-R20) [[2]](diffhunk://#diff-15b7a36bb810457a4640087e0a82d67ed0103befe4ae35c59eb4db8824a19745L35-R35) [[3]](diffhunk://#diff-15b7a36bb810457a4640087e0a82d67ed0103befe4ae35c59eb4db8824a19745L54-R54)

### Command State Updates:
* Updated `CommandState` to use `NormalCommandCategory.ALL` as the default value for the `filtered` property.
* Modified `CommandStateHolder` to initialize the `filtered` state with `NormalCommandCategory.ALL` and updated the `clickTab` method accordingly. [[1]](diffhunk://#diff-eac728beb60793661728b7d0171bdf544894a35760ce99bc0049b6e8cd48f310L29-R29) [[2]](diffhunk://#diff-eac728beb60793661728b7d0171bdf544894a35760ce99bc0049b6e8cd48f310L68-R68)

### Command Tab Updates:
* Adjusted `CommandTab` to handle `NormalCommandCategory.ALL` instead of `null`. [[1]](diffhunk://#diff-b99988eb96d4f740992060911a578aeab7b543e7934b0cf8ff5a3844e8ff81d5L18-R29) [[2]](diffhunk://#diff-b99988eb96d4f740992060911a578aeab7b543e7934b0cf8ff5a3844e8ff81d5L51-R51)