### PR TITLE
Refactor screens

### DIFF
--- a/.idea/artifacts/adbpad_jvm_2_0_0.xml
+++ b/.idea/artifacts/adbpad_jvm_2_0_0.xml
@@ -1,0 +1,8 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="adbpad-jvm-2.0.0">
+    <output-path>$PROJECT_DIR$/build/libs</output-path>
+    <root id="archive" name="adbpad-jvm-2.0.0.jar">
+      <element id="module-output" name="adbpad.jvmMain" />
+    </root>
+  </artifact>
+</component>

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -209,6 +209,7 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                             }
 
                             SettingScreen(
+                                initialized = settingState.initialized,
                                 languages = settingState.languages,
                                 selectLanguage = settingState.selectedLanguage,
                                 onUpdateLanguage = { settingAction(SettingAction.UpdateLanguage(it)) },
@@ -222,7 +223,9 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                 isValidAdbPortNumber = settingState.isValidAdbPortNumber,
                                 onSave = { settingAction(SettingAction.Save) },
                                 canSave = settingState.canSave,
+                                isSaving = settingState.isSaving,
                                 onCancel = { mainStateHolder.refresh() },
+                                canCancel = settingState.canCancel,
                             )
                         }
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -29,6 +29,7 @@ import jp.kaleidot725.adbpad.ui.component.NavigationRail
 import jp.kaleidot725.adbpad.ui.di.stateHolderModule
 import jp.kaleidot725.adbpad.ui.screen.CommandScreen
 import jp.kaleidot725.adbpad.ui.screen.ScreenLayout
+import jp.kaleidot725.adbpad.ui.screen.command.CommandAction
 import jp.kaleidot725.adbpad.ui.screen.error.AdbErrorScreen
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotAction
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotScreen
@@ -118,14 +119,14 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                         MainCategory.Command -> {
                             val commandStateHolder = mainStateHolder.commandStateHolder
                             val commandState by commandStateHolder.state.collectAsState()
+                            val commandAction = commandStateHolder::onAction
+
                             CommandScreen(
                                 commands = commandState.commands,
                                 filtered = commandState.filtered,
-                                onClickFilter = commandStateHolder::clickTab,
+                                onClickFilter = { commandAction(CommandAction.ClickCategoryTab(it)) },
                                 canExecute = commandState.canExecuteCommand,
-                                onExecute = { command ->
-                                    commandStateHolder.executeCommand(command)
-                                },
+                                onExecute = { command -> commandAction(CommandAction.ExecuteCommand(command)) },
                             )
                         }
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt
@@ -59,7 +59,6 @@ class MainStateHolder(
 
     private val children: List<ChildStateHolder<*>> =
         listOf(
-            commandStateHolder,
             topStateHolder,
         )
 
@@ -74,6 +73,7 @@ class MainStateHolder(
         children.forEach { it.setup() }
         textCommandStateHolder.onSetup()
         screenshotStateHolder.onSetup()
+        commandStateHolder.onSetup()
     }
 
     override fun refresh() {
@@ -84,12 +84,14 @@ class MainStateHolder(
         children.forEach { it.refresh() }
         textCommandStateHolder.onRefresh()
         screenshotStateHolder.onRefresh()
+        commandStateHolder.onRefresh()
     }
 
     override fun dispose() {
         children.forEach { it.dispose() }
         textCommandStateHolder.onDispose()
         screenshotStateHolder.onDispose()
+        commandStateHolder.onDispose()
     }
 
     fun saveSetting(windowSize: WindowSize) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/core/mvi/MVIDelegate.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/core/mvi/MVIDelegate.kt
@@ -3,6 +3,7 @@ package jp.kaleidot725.adbpad.core.mvi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,7 +30,9 @@ class MVIDelegate<UiState : MVIState, UiAction : MVIAction, SideEffect : MVISide
 
     override fun onRefresh() {}
 
-    override fun onDispose() {}
+    override fun onDispose() {
+        coroutineScope.cancel()
+    }
 
     override fun update(block: UiState.() -> UiState) {
         uiState.update { block(it) }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/DefaultOutlineTextField.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/DefaultOutlineTextField.kt
@@ -1,0 +1,53 @@
+package jp.kaleidot725.adbpad.ui.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun DefaultOutlineTextField(
+    id: Any? = null,
+    label: String,
+    initialText: String,
+    placeHolder: String,
+    isError: Boolean,
+    onUpdateText: (String) -> Unit,
+    maxLines: Int = 1,
+    modifier: Modifier = Modifier,
+) {
+    var localText by remember(id) { mutableStateOf(initialText) }
+    OutlinedTextField(
+        label = { Text(label) },
+        placeholder = { Text(placeHolder) },
+        value = localText,
+        onValueChange = {
+            localText = it
+            onUpdateText(it)
+        },
+        maxLines = maxLines,
+        textStyle = TextStyle(color = MaterialTheme.colors.onSurface, fontSize = 16.sp),
+        isError = isError,
+        modifier = modifier,
+    )
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    DefaultOutlineTextField(
+        initialText = "",
+        placeHolder = "Search",
+        onUpdateText = {},
+        label = "LABEL",
+        isError = false,
+    )
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/DefaultTextField.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/DefaultTextField.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.sp
 
 @Composable
 fun DefaultTextField(
-    id: String = "",
+    id: Any? = null,
     initialText: String,
     placeHolder: String,
     onUpdateText: (String) -> Unit,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandAction.kt
@@ -1,0 +1,15 @@
+package jp.kaleidot725.adbpad.ui.screen.command
+
+import jp.kaleidot725.adbpad.core.mvi.MVIAction
+import jp.kaleidot725.adbpad.domain.model.command.NormalCommand
+import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
+
+sealed class CommandAction : MVIAction {
+    data class ExecuteCommand(
+        val command: NormalCommand,
+    ) : CommandAction()
+
+    data class ClickCategoryTab(
+        val category: NormalCommandCategory,
+    ) : CommandAction()
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandSideEffect.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandSideEffect.kt
@@ -1,0 +1,5 @@
+package jp.kaleidot725.adbpad.ui.screen.command
+
+import jp.kaleidot725.adbpad.core.mvi.MVISideEffect
+
+class CommandSideEffect : MVISideEffect

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandState.kt
@@ -1,5 +1,6 @@
 package jp.kaleidot725.adbpad.ui.screen.command
 
+import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandGroup
 import jp.kaleidot725.adbpad.domain.model.device.Device
@@ -8,6 +9,6 @@ data class CommandState(
     val commands: NormalCommandGroup = NormalCommandGroup.Empty,
     val filtered: NormalCommandCategory = NormalCommandCategory.ALL,
     val selectedDevice: Device? = null,
-) {
+) : MVIState {
     val canExecuteCommand: Boolean get() = selectedDevice != null
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
@@ -1,71 +1,78 @@
 package jp.kaleidot725.adbpad.ui.screen.command
 
+import jp.kaleidot725.adbpad.core.mvi.MVI
+import jp.kaleidot725.adbpad.core.mvi.mvi
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommand
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
-import jp.kaleidot725.adbpad.domain.model.command.NormalCommandGroup
-import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.usecase.command.ExecuteCommandUseCase
 import jp.kaleidot725.adbpad.domain.usecase.command.GetNormalCommandGroup
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
-import jp.kaleidot725.adbpad.ui.common.ChildStateHolder
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class CommandStateHolder(
     private val getNormalCommandGroup: GetNormalCommandGroup,
     private val executeCommandUseCase: ExecuteCommandUseCase,
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
-) : ChildStateHolder<CommandState> {
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main + Dispatchers.IO)
-    private val commands: MutableStateFlow<NormalCommandGroup> = MutableStateFlow(NormalCommandGroup.Empty)
-    private val filtered: MutableStateFlow<NormalCommandCategory> = MutableStateFlow(NormalCommandCategory.ALL)
-    private val selectedDevice: StateFlow<Device?> =
-        getSelectedDeviceFlowUseCase()
-            .stateIn(coroutineScope, SharingStarted.WhileSubscribed(), null)
-
-    override val state: StateFlow<CommandState> =
-        combine(
-            commands,
-            filtered,
-            selectedDevice,
-        ) { commands, filtered, selectedDevice ->
-            CommandState(commands, filtered, selectedDevice)
-        }.stateIn(coroutineScope, SharingStarted.WhileSubscribed(), CommandState())
-
-    override fun setup() {
-        commands.value = getNormalCommandGroup()
-    }
-
-    override fun refresh() {
-        commands.value = getNormalCommandGroup()
-    }
-
-    override fun dispose() {
-        coroutineScope.cancel()
-    }
-
-    fun executeCommand(command: NormalCommand) {
-        val selectedDevice = state.value.selectedDevice ?: return
+) : MVI<CommandState, CommandAction, CommandSideEffect> by mvi(initialUiState = CommandState()) {
+    override fun onSetup() {
         coroutineScope.launch {
-            executeCommandUseCase(
-                device = selectedDevice,
-                command = command,
-                onStart = { commands.value = getNormalCommandGroup() },
-                onFailed = { commands.value = getNormalCommandGroup() },
-                onComplete = { commands.value = getNormalCommandGroup() },
-            )
+            getSelectedDeviceFlowUseCase().collect {
+                update { this.copy(selectedDevice = it) }
+            }
+        }
+        coroutineScope.launch {
+            val commands = getNormalCommandGroup()
+            update { this.copy(commands = commands) }
         }
     }
 
-    fun clickTab(filtered: NormalCommandCategory) {
-        this.filtered.value = filtered
+    override fun onRefresh() {
+        coroutineScope.launch {
+            val commands = getNormalCommandGroup()
+            update { this.copy(commands = commands) }
+        }
+    }
+
+    override fun onDispose() {
+        coroutineScope.cancel()
+    }
+
+    override fun onAction(uiAction: CommandAction) {
+        coroutineScope.launch {
+            when (uiAction) {
+                is CommandAction.ClickCategoryTab -> clickTab(uiAction.category)
+                is CommandAction.ExecuteCommand -> executeCommand(uiAction.command)
+            }
+        }
+    }
+
+    private suspend fun executeCommand(command: NormalCommand) {
+        val selectedDevice = state.value.selectedDevice ?: return
+        executeCommandUseCase(
+            device = selectedDevice,
+            command = command,
+            onStart = {
+                update {
+                    this.copy(commands = getNormalCommandGroup())
+                }
+            },
+            onFailed = {
+                update {
+                    this.copy(commands = getNormalCommandGroup())
+                }
+            },
+            onComplete = {
+                update {
+                    this.copy(commands = getNormalCommandGroup())
+                }
+            },
+        )
+    }
+
+    private fun clickTab(filtered: NormalCommandCategory) {
+        update {
+            this.copy(filtered = filtered)
+        }
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
@@ -7,7 +7,6 @@ import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 import jp.kaleidot725.adbpad.domain.usecase.command.ExecuteCommandUseCase
 import jp.kaleidot725.adbpad.domain.usecase.command.GetNormalCommandGroup
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 class CommandStateHolder(
@@ -32,10 +31,6 @@ class CommandStateHolder(
             val commands = getNormalCommandGroup()
             update { this.copy(commands = commands) }
         }
-    }
-
-    override fun onDispose() {
-        coroutineScope.cancel()
     }
 
     override fun onAction(uiAction: CommandAction) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
@@ -11,7 +11,6 @@ import jp.kaleidot725.adbpad.domain.usecase.screenshot.GetScreenshotCommandUseCa
 import jp.kaleidot725.adbpad.domain.usecase.screenshot.TakeScreenshotUseCase
 import jp.kaleidot725.adbpad.domain.utils.ClipBoardUtils
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -46,10 +45,6 @@ class ScreenshotStateHolder(
 
             initPreviews()
         }
-    }
-
-    override fun onDispose() {
-        coroutineScope.cancel()
     }
 
     override fun onAction(uiAction: ScreenshotAction) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingAction.kt
@@ -1,0 +1,25 @@
+package jp.kaleidot725.adbpad.ui.screen.setting
+
+import jp.kaleidot725.adbpad.core.mvi.MVIAction
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.domain.model.setting.Appearance
+
+sealed class SettingAction : MVIAction {
+    data object Save : SettingAction()
+
+    data class UpdateLanguage(
+        val value: Language.Type,
+    ) : SettingAction()
+
+    data class UpdateAppearance(
+        val value: Appearance,
+    ) : SettingAction()
+
+    data class UpdateAdbDirectoryPath(
+        val value: String,
+    ) : SettingAction()
+
+    data class UpdateAdbPortNumberPath(
+        val value: String,
+    ) : SettingAction()
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingScreen.kt
@@ -5,10 +5,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -18,15 +21,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.Appearance
+import jp.kaleidot725.adbpad.ui.component.DefaultOutlineTextField
 import jp.kaleidot725.adbpad.ui.component.FloatingDialog
 import jp.kaleidot725.adbpad.ui.component.RadioButtons
 import jp.kaleidot725.adbpad.ui.screen.setting.component.LanguageDropButton
-import jp.kaleidot725.adbpad.ui.screen.setting.component.SettingField
 import jp.kaleidot725.adbpad.ui.screen.setting.component.SettingHeader
 import jp.kaleidot725.adbpad.ui.screen.setting.component.SettingTitle
 
 @Composable
 fun SettingScreen(
+    initialized: Boolean,
     languages: List<Language.Type>,
     selectLanguage: Language.Type,
     onUpdateLanguage: (Language.Type) -> Unit,
@@ -40,7 +44,9 @@ fun SettingScreen(
     isValidAdbPortNumber: Boolean,
     onSave: () -> Unit,
     canSave: Boolean,
+    isSaving: Boolean,
     onCancel: () -> Unit,
+    canCancel: Boolean,
 ) {
     FloatingDialog(
         modifier =
@@ -49,6 +55,13 @@ fun SettingScreen(
                 .fillMaxHeight()
                 .padding(vertical = 32.dp),
     ) {
+        if (!initialized) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator()
+            }
+            return@FloatingDialog
+        }
+
         Box(modifier = Modifier.padding(16.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 SettingHeader(modifier = Modifier.fillMaxWidth())
@@ -88,18 +101,24 @@ fun SettingScreen(
                     modifier = Modifier.padding(horizontal = 4.dp),
                 )
 
-                SettingField(
-                    title = Language.settingAdbDirectoryPathTitle,
-                    input = adbDirectoryPath,
+                DefaultOutlineTextField(
+                    id = initialized,
+                    initialText = adbDirectoryPath,
+                    onUpdateText = onChangeAdbDirectoryPath,
+                    label = Language.settingAdbDirectoryPathTitle,
+                    modifier = Modifier.fillMaxWidth(),
                     isError = !isValidAdbDirectoryPath,
-                    onValueChange = onChangeAdbDirectoryPath,
+                    placeHolder = "",
                 )
 
-                SettingField(
-                    title = Language.settingAdbPortNumberTitle,
-                    input = adbPortNumber,
+                DefaultOutlineTextField(
+                    id = initialized,
+                    initialText = adbPortNumber,
+                    onUpdateText = onChangeAdbPortNumber,
+                    label = Language.settingAdbPortNumberTitle,
+                    modifier = Modifier.fillMaxWidth(),
                     isError = !isValidAdbPortNumber,
-                    onValueChange = onChangeAdbPortNumber,
+                    placeHolder = "",
                 )
             }
 
@@ -107,19 +126,35 @@ fun SettingScreen(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier.align(Alignment.BottomEnd),
             ) {
-                Button(onClick = onCancel) {
+                Button(
+                    onClick = onCancel,
+                    enabled = canCancel,
+                ) {
                     Text(
                         text = Language.cancel,
                         modifier = Modifier.width(100.dp),
                         textAlign = TextAlign.Center,
                     )
                 }
-                Button(onClick = onSave, enabled = canSave) {
-                    Text(
-                        text = Language.save,
-                        modifier = Modifier.width(100.dp),
-                        textAlign = TextAlign.Center,
-                    )
+                Button(
+                    onClick = onSave,
+                    enabled = canSave,
+                ) {
+                    if (isSaving) {
+                        Box(
+                            modifier = Modifier.width(100.dp),
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(12.dp).align(Alignment.Center),
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = Language.save,
+                            modifier = Modifier.width(100.dp),
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                 }
             }
         }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingSideEffect.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingSideEffect.kt
@@ -1,0 +1,7 @@
+package jp.kaleidot725.adbpad.ui.screen.setting
+
+import jp.kaleidot725.adbpad.core.mvi.MVISideEffect
+
+sealed class SettingSideEffect : MVISideEffect {
+    data object Saved : SettingSideEffect()
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingState.kt
@@ -5,18 +5,24 @@ import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.Appearance
 
 data class SettingState(
-    val languages: List<Language.Type> = Language.Type.values().toList(),
+    val initialized: Boolean = false,
+    val languages: List<Language.Type> = Language.Type.entries,
     val selectedLanguage: Language.Type = Language.Type.ENGLISH,
     val appearance: Appearance = Appearance.DARK,
     val adbDirectoryPath: String = "",
     val adbPortNumber: String = "",
-    val isRestartingAdb: Boolean = false,
+    val isSaving: Boolean = false,
 ) : MVIState {
     val isValidAdbDirectoryPath: Boolean = adbDirectoryPath.isNotEmpty()
     val isValidAdbPortNumber: Boolean = adbPortNumber.toIntOrNull() != null
 
     val canSave: Boolean
         get() {
-            return isValidAdbDirectoryPath && isValidAdbPortNumber
+            return isValidAdbDirectoryPath && isValidAdbPortNumber && !isSaving
+        }
+
+    val canCancel: Boolean
+        get() {
+            return !isSaving
         }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingState.kt
@@ -1,5 +1,6 @@
 package jp.kaleidot725.adbpad.ui.screen.setting
 
+import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.Appearance
 
@@ -10,7 +11,7 @@ data class SettingState(
     val adbDirectoryPath: String = "",
     val adbPortNumber: String = "",
     val isRestartingAdb: Boolean = false,
-) {
+) : MVIState {
     val isValidAdbDirectoryPath: Boolean = adbDirectoryPath.isNotEmpty()
     val isValidAdbPortNumber: Boolean = adbPortNumber.toIntOrNull() != null
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/SettingField.kt
@@ -2,24 +2,24 @@ package jp.kaleidot725.adbpad.ui.screen.setting.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import jp.kaleidot725.adbpad.ui.component.DefaultOutlineTextField
 
 @Composable
 fun SettingField(
     title: String,
-    input: String,
+    initialInput: String,
     isError: Boolean,
     onValueChange: (String) -> Unit,
 ) {
-    OutlinedTextField(
-        value = input,
-        onValueChange = onValueChange,
-        label = { Text(title) },
+    DefaultOutlineTextField(
+        initialText = initialInput,
+        onUpdateText = onValueChange,
+        label = title,
         modifier = Modifier.fillMaxWidth(),
         isError = isError,
+        placeHolder = "",
     )
 }
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandStateHolder.kt
@@ -7,7 +7,6 @@ import jp.kaleidot725.adbpad.domain.repository.TextCommandRepository
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
 import jp.kaleidot725.adbpad.domain.usecase.text.ExecuteTextCommandUseCase
 import jp.kaleidot725.adbpad.domain.usecase.text.GetTextCommandUseCase
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 class TextCommandStateHolder(
@@ -35,10 +34,6 @@ class TextCommandStateHolder(
                 this.copy(commands = commands)
             }
         }
-    }
-
-    override fun onDispose() {
-        coroutineScope.cancel()
     }
 
     override fun onAction(uiAction: TextCommandAction) {


### PR DESCRIPTION
This pull request includes several changes to improve the state management and UI components in the `adbpad` project. The most important changes include the introduction of new actions and side effects for the `Command` and `Setting` screens, the addition of a new `DefaultOutlineTextField` component, and the refactoring of state holders to use the MVI pattern.

### State Management Improvements:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandAction.kt`](diffhunk://#diff-ca35fa6c5eb2415bd9c38406b9a307530ef2486f519067e545b5fde277dbc247R1-R15): Added new `CommandAction` sealed class to handle command-related actions.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt`](diffhunk://#diff-eac728beb60793661728b7d0171bdf544894a35760ce99bc0049b6e8cd48f310R3-R71): Refactored `CommandStateHolder` to use the MVI pattern and handle actions more effectively.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingAction.kt`](diffhunk://#diff-5fd9aed25503b9ae1342a2f1ebd1b1b0a8072da89e19206e0cb14e88b53d2722R1-R25): Added new `SettingAction` sealed class to handle setting-related actions.

### UI Component Enhancements:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/DefaultOutlineTextField.kt`](diffhunk://#diff-931be506ea71fed7999105e859b3b4158ec3d544b878ed41d72c5c509f70403aR1-R53): Added new `DefaultOutlineTextField` component to provide a customizable outlined text field.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt`](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4R125-R132): Updated `App` function to use new actions and effects for command and setting screens. [[1]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4R125-R132) [[2]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4L187-R228)

### Miscellaneous Improvements:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/core/mvi/MVIDelegate.kt`](diffhunk://#diff-43cedaa8c6eb42d5554132691fa10ddbfdd8fe61dd058b02cb149eb7e760d0c0L32-R35): Updated `MVIDelegate` to cancel coroutine scope on dispose.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandState.kt`](diffhunk://#diff-defc64014edfb557c492db6a14682b43bec7d4e3f6ab61fe499402200f1f244aL11-R12): Implemented `MVIState` interface in `CommandState`.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt`](diffhunk://#diff-b25cde231c7987ec30013c1d6cc2a224ceb5a5f7fa85b4337cbc256ab7d2af7cL51-L54): Removed unnecessary coroutine scope cancellation in `ScreenshotStateHolder`.