### PR TITLE
Feat/fix bug

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -154,6 +154,7 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                 screenshots = screenshotState.previews,
                                 canCapture = screenshotState.canExecute,
                                 isCapturing = screenshotState.isCapturing,
+                                selectCommand = screenshotState.selectedCommand,
                                 commands = screenshotState.commands,
                                 searchText = screenshotState.searchText,
                                 onOpenDirectory = {
@@ -179,6 +180,9 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                 },
                                 onUpdateSearchText = {
                                     onAction(ScreenshotAction.UpdateSearchText(it))
+                                },
+                                onSelectCommand = {
+                                    onAction(ScreenshotAction.SelectScreenshotCommand(it))
                                 },
                             )
                         }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/ScreenshotCommand.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/ScreenshotCommand.kt
@@ -4,21 +4,20 @@ import jp.kaleidot725.adbpad.domain.model.language.Language
 
 interface ScreenshotCommand {
     val title: String
-    val isRunning: Boolean
 
-    data class Dark(override val isRunning: Boolean) : ScreenshotCommand {
+    data object Dark : ScreenshotCommand {
         override val title: String get() = Language.screenshotTakeByDarkTheme
     }
 
-    data class Light(override val isRunning: Boolean) : ScreenshotCommand {
+    data object Light : ScreenshotCommand {
         override val title: String get() = Language.screenshotTakeByLightTheme
     }
 
-    data class Current(override val isRunning: Boolean) : ScreenshotCommand {
+    data object Current : ScreenshotCommand {
         override val title: String get() = Language.screenshotTakeByCurrentTheme
     }
 
-    data class Both(override val isRunning: Boolean) : ScreenshotCommand {
+    data object Both : ScreenshotCommand {
         override val title: String get() = Language.screenshotTakeByBothTheme
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -98,7 +98,7 @@ object ChineseResources : StringResources {
 
     override val settingLanguageHeader = "语言"
     override val settingLanguageEnglish = "英语"
-    override val settingLanguageJapanese = "日语 (日本語)"
+    override val settingLanguageJapanese = "日语"
     override val settingLanguageChinese = "简体中文"
     override val settingLanguageTurkish = "土耳其语"
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -98,9 +98,9 @@ object EnglishResources : StringResources {
 
     override val settingLanguageHeader = "Language"
     override val settingLanguageEnglish = "English"
-    override val settingLanguageJapanese = "Japanese(日本語)"
-    override val settingLanguageChinese = "Chinese(简体中文)"
-    override val settingLanguageTurkish = "Turkish(Türkçe)"
+    override val settingLanguageJapanese = "Japanese"
+    override val settingLanguageChinese = "Chinese"
+    override val settingLanguageTurkish = "Turkish"
 
     override val settingAppearanceHeader = "Appearance"
     override val settingAdbHeader = "ADB"

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -96,10 +96,10 @@ object JapaneseResources : StringResources {
     override val menuScreenshot = "スクリーンショット"
 
     override val settingLanguageHeader = "表示言語"
-    override val settingLanguageEnglish = "英語(English)"
+    override val settingLanguageEnglish = "英語"
     override val settingLanguageJapanese = "日本語"
     override val settingLanguageChinese = "簡体字中国語"
-    override val settingLanguageTurkish = "土耳其语(Türkçe)"
+    override val settingLanguageTurkish = "トルコ語"
 
     override val settingAppearanceHeader = "テーマ"
     override val settingAdbHeader = "ADB"

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -1,6 +1,6 @@
 package jp.kaleidot725.adbpad.domain.model.language.resources
 
-val APP_VERSION = "v2.0.0"
+val APP_VERSION = "v2.0.1"
 
 interface StringResources {
     val windowTitle: String

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -97,9 +97,9 @@ object TurkishResources : StringResources {
     override val menuScreenshot = "Ekran Görüntüsü"
 
     override val settingLanguageHeader = "Dil"
-    override val settingLanguageEnglish = "İngilizce (English)"
-    override val settingLanguageJapanese = "Japonca (日本語)"
-    override val settingLanguageChinese = "Çince (简体中文)"
+    override val settingLanguageEnglish = "İngilizce"
+    override val settingLanguageJapanese = "Japonca"
+    override val settingLanguageChinese = "Çince"
     override val settingLanguageTurkish = "Türkçe"
 
     override val settingAppearanceHeader = "Görünüm"

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/repository/ScreenshotCommandRepository.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/repository/ScreenshotCommandRepository.kt
@@ -18,6 +18,4 @@ interface ScreenshotCommandRepository {
     suspend fun getScreenshots(): List<Screenshot>
 
     suspend fun delete(screenshot: Screenshot)
-
-    fun clear()
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/refresh/RefreshUseCase.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/refresh/RefreshUseCase.kt
@@ -11,7 +11,6 @@ class RefreshUseCase(
 ) {
     operator fun invoke() {
         commandRepository.clear()
-        screenshotCommandRepository.clear()
         textCommandRepository.clear()
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotAction.kt
@@ -9,6 +9,10 @@ sealed class ScreenshotAction : MVIAction {
         val text: String,
     ) : ScreenshotAction()
 
+    data class SelectScreenshotCommand(
+        val command: ScreenshotCommand,
+    ) : ScreenshotAction()
+
     data class TakeScreenshot(
         val command: ScreenshotCommand,
     ) : ScreenshotAction()

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
@@ -43,11 +43,13 @@ fun ScreenshotScreen(
     screenshots: List<Screenshot>,
     canCapture: Boolean,
     isCapturing: Boolean,
+    selectCommand: ScreenshotCommand,
     commands: List<ScreenshotCommand>,
     searchText: String,
     onOpenDirectory: () -> Unit,
     onCopyScreenshot: () -> Unit,
     onDeleteScreenshot: () -> Unit,
+    onSelectCommand: (ScreenshotCommand) -> Unit,
     onTakeScreenshot: (ScreenshotCommand) -> Unit,
     onSelectScreenshot: (Screenshot) -> Unit,
     onNextScreenshot: () -> Unit,
@@ -101,6 +103,8 @@ fun ScreenshotScreen(
                     )
 
                     ScreenshotMenu(
+                        selectedCommand = selectCommand,
+                        onSelectCommand = onSelectCommand,
                         commands = commands,
                         canCapture = canCapture,
                         isCapturing = isCapturing,
@@ -145,6 +149,7 @@ private fun ScreenshotScreen_Preview() {
         screenshots = emptyList(),
         canCapture = true,
         isCapturing = false,
+        selectCommand = ScreenshotCommand.Both,
         commands = emptyList(),
         searchText = "",
         onOpenDirectory = {},
@@ -155,5 +160,6 @@ private fun ScreenshotScreen_Preview() {
         onNextScreenshot = {},
         onPreviousScreenshot = {},
         onUpdateSearchText = {},
+        onSelectCommand = {},
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotState.kt
@@ -9,6 +9,7 @@ data class ScreenshotState(
     val searchText: String = "",
     val preview: Screenshot = Screenshot(null),
     val previews: List<Screenshot> = emptyList(),
+    val selectedCommand: ScreenshotCommand = ScreenshotCommand.Both,
     val commands: List<ScreenshotCommand> = emptyList(),
     val selectedDevice: Device? = null,
     val isCapturing: Boolean = false,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
@@ -26,7 +26,12 @@ class ScreenshotStateHolder(
     override fun onSetup() {
         coroutineScope.launch {
             val commands = getScreenshotCommandUseCase()
-            update { copy(commands = commands) }
+            update {
+                copy(
+                    selectedCommand = commands.first(),
+                    commands = commands,
+                )
+            }
 
             initPreviews()
         }
@@ -41,7 +46,12 @@ class ScreenshotStateHolder(
     override fun onRefresh() {
         coroutineScope.launch {
             val commands = getScreenshotCommandUseCase()
-            update { copy(commands = commands) }
+            update {
+                copy(
+                    selectedCommand = commands.first(),
+                    commands = commands,
+                )
+            }
 
             initPreviews()
         }
@@ -58,6 +68,7 @@ class ScreenshotStateHolder(
                 ScreenshotAction.NextScreenshot -> nextScreenshot()
                 ScreenshotAction.PreviousScreenshot -> previousScreenshot()
                 is ScreenshotAction.UpdateSearchText -> updateSearchText(uiAction.text)
+                is ScreenshotAction.SelectScreenshotCommand -> selectScreenshotCommand(uiAction.command)
             }
         }
     }
@@ -156,6 +167,14 @@ class ScreenshotStateHolder(
             this.copy(
                 previews = screenshots,
                 preview = screenshot,
+            )
+        }
+    }
+
+    private fun selectScreenshotCommand(command: ScreenshotCommand) {
+        update {
+            this.copy(
+                selectedCommand = command,
             )
         }
     }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotButton.kt
@@ -95,7 +95,7 @@ fun ScreenshotButton(
 private fun ScreenshotButton_Preview() {
     MaterialTheme {
         ScreenshotButton(
-            selectedCommand = ScreenshotCommand.Current(false),
+            selectedCommand = ScreenshotCommand.Current,
             canCapture = true,
             isCapturing = false,
             onTake = {},

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,6 +25,8 @@ import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 
 @Composable
 fun ScreenshotDropDownButton(
+    selectedCommand: ScreenshotCommand,
+    onSelectCommand: (ScreenshotCommand) -> Unit,
     commands: List<ScreenshotCommand>,
     canCapture: Boolean,
     isCapturing: Boolean,
@@ -33,15 +34,13 @@ fun ScreenshotDropDownButton(
     modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val initialCommand by rememberUpdatedState(commands.firstOrNull())
-    var selectedCommand: ScreenshotCommand? by remember { mutableStateOf(null) }
 
     Box(modifier) {
         ScreenshotButton(
-            selectedCommand = selectedCommand ?: initialCommand,
+            selectedCommand = selectedCommand,
             canCapture = canCapture,
             isCapturing = isCapturing,
-            onTake = { selectedCommand?.let { onTakeScreenshot(it) } },
+            onTake = { onTakeScreenshot(selectedCommand) },
             onChangeType = { expanded = true },
         )
 
@@ -53,7 +52,7 @@ fun ScreenshotDropDownButton(
             commands.forEach { command ->
                 DropdownMenuItem(
                     onClick = {
-                        selectedCommand = command
+                        onSelectCommand(command)
                         expanded = false
                     },
                 ) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotMenu.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotMenu.kt
@@ -8,6 +8,8 @@ import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 
 @Composable
 fun ScreenshotMenu(
+    selectedCommand: ScreenshotCommand,
+    onSelectCommand: (ScreenshotCommand) -> Unit,
     commands: List<ScreenshotCommand>,
     canCapture: Boolean,
     isCapturing: Boolean,
@@ -18,6 +20,8 @@ fun ScreenshotMenu(
         modifier = modifier,
     ) {
         ScreenshotDropDownButton(
+            selectedCommand = selectedCommand,
+            onSelectCommand = onSelectCommand,
             commands = commands,
             canCapture = canCapture,
             isCapturing = isCapturing,
@@ -30,7 +34,9 @@ fun ScreenshotMenu(
 @Composable
 private fun Preview() {
     ScreenshotMenu(
-        commands = listOf(ScreenshotCommand.Current(isRunning = false)),
+        selectedCommand = ScreenshotCommand.Both,
+        onSelectCommand = {},
+        commands = listOf(ScreenshotCommand.Current),
         canCapture = false,
         isCapturing = false,
         onTakeScreenshot = {},


### PR DESCRIPTION
This pull request includes several changes to the `adbpad` project, focusing on improving the functionality and user interface for screenshot commands, as well as updating string resources and simplifying the codebase.

### Screenshot functionality improvements:
* Added `selectCommand` and `onSelectCommand` parameters to the `ScreenshotScreen` and `ScreenshotDropDownButton` components to allow users to select a screenshot command. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt` [[1]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4R157) [[2]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4R184-R186); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt` [[3]](diffhunk://#diff-3884d1f60a0ab3ccc7c493f6591cc96c7affa387151034922f6c59c7a697d67aR46-R52) [[4]](diffhunk://#diff-3884d1f60a0ab3ccc7c493f6591cc96c7affa387151034922f6c59c7a697d67aR106-R107) [[5]](diffhunk://#diff-3884d1f60a0ab3ccc7c493f6591cc96c7affa387151034922f6c59c7a697d67aR152) [[6]](diffhunk://#diff-3884d1f60a0ab3ccc7c493f6591cc96c7affa387151034922f6c59c7a697d67aR163); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt` [[7]](diffhunk://#diff-488cecfdf3d6754752779bfd873bb93143c7e34d7dcf1d8d3459ad3e634441d6L20) [[8]](diffhunk://#diff-488cecfdf3d6754752779bfd873bb93143c7e34d7dcf1d8d3459ad3e634441d6R28-R43)
* Updated `ScreenshotState` and `ScreenshotStateHolder` to include the selected command and handle the new `SelectScreenshotCommand` action. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotState.kt` [[1]](diffhunk://#diff-f42770393f2c842f197b250ea60cf846d6ed82d13afce9b1c90eb76ba161c4dfR12); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt` [[2]](diffhunk://#diff-b25cde231c7987ec30013c1d6cc2a224ceb5a5f7fa85b4337cbc256ab7d2af7cL29-R34) [[3]](diffhunk://#diff-b25cde231c7987ec30013c1d6cc2a224ceb5a5f7fa85b4337cbc256ab7d2af7cL44-R54) [[4]](diffhunk://#diff-b25cde231c7987ec30013c1d6cc2a224ceb5a5f7fa85b4337cbc256ab7d2af7cR71) [[5]](diffhunk://#diff-b25cde231c7987ec30013c1d6cc2a224ceb5a5f7fa85b4337cbc256ab7d2af7cR173-R180)

### String resources updates:
* Simplified the language names in the `StringResources` for various languages by removing the native script from the names. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt` [[1]](diffhunk://#diff-594031841b8fb02bbafe5d12494fb8440c913435b2df7a53e2b3da6c72e4369eL101-R101); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt` [[2]](diffhunk://#diff-ed0f482c0e642d8cb3cb91655707c86d2bfedd893b4d0a6c2c21f35122c6437fL101-R103); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt` [[3]](diffhunk://#diff-2477d85a4cf96726bf08ddb8fd0be90e659bbad751dffc081d24cdd549b6c7f3L99-R102); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt` [[4]](diffhunk://#diff-b35228af6b444eabcaa2b8f89dd8fd4c85531ac2a27b8b37ab0ba12f623d7051L100-R102)

### Codebase simplification:
* Removed the `isRunning` property from `ScreenshotCommand` and converted the command classes to `data object` for simplicity. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/ScreenshotCommand.kt` [src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/command/ScreenshotCommand.ktL7-R20](diffhunk://#diff-59d97cbf5d8bd5c9a1f56892450fb0eb4d7acd0748d5c1b983db85b84372c1b9L7-R20))
* Removed the `clear` method and the `runningCommands` set from `ScreenshotCommandRepositoryImpl` as they were no longer needed. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/repository/ScreenshotCommandRepository.kt` [[1]](diffhunk://#diff-2a011d4638583701f877b12f1ee81f672d2f181187d16213f65c2f4b2b0f26ceL21-L22); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/refresh/RefreshUseCase.kt` [[2]](diffhunk://#diff-a02435b7d0acc1aa3b8925706b09c92b1a06d70b0a0bd2b9673ddfc88fb3bebdL14); `src/jvmMain/kotlin/jp/kaleidot725/adbpad/repository/impl/ScreenshotCommandRepositoryImpl.kt` [[3]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L23-L37) [[4]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L48) [[5]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L62-L86) [[6]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L135-R126) [[7]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L155-R145) [[8]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L174)

### Version update:
* Updated the application version from `v2.0.0` to `v2.0.1`. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt` [src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.ktL3-R3](diffhunk://#diff-c176a2a6de40c297218931afa52676182df0f30d505dec87a61767159bfe0ecbL3-R3))