### PR TITLE
feat: add screenshot zoom

### DIFF
--- a/.idea/artifacts/adbpad_jvm_2_1_0.xml
+++ b/.idea/artifacts/adbpad_jvm_2_1_0.xml
@@ -1,0 +1,8 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="adbpad-jvm-2.1.0">
+    <output-path>$PROJECT_DIR$/build/libs</output-path>
+    <root id="archive" name="adbpad-jvm-2.1.0.jar">
+      <element id="module-output" name="adbpad.jvmMain" />
+    </root>
+  </artifact>
+</component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "jp.kaleidot725"
-version = "2.0.0"
+version = "2.1.0"
 
 kotlin {
     jvm()
@@ -39,6 +39,7 @@ kotlin {
         implementation(libs.ktor.client.okhttp)
         implementation(libs.jSystemThemeDetectorVer)
         implementation(libs.coil)
+        implementation("net.engawapg.lib:zoomable:2.4.0")
     }
     sourceSets.jvmTest.dependencies {
         implementation(libs.junit5)

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/UserColor.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/UserColor.kt
@@ -15,6 +15,16 @@ object UserColor {
         }
     }
 
+    @Composable
+    fun getFloatingBackgroundColor(): Color {
+        val isLight = MaterialTheme.colors.isLight
+        return if (isLight) {
+            Color(0xFFDDDDDD)
+        } else {
+            Color(0x0FF333333)
+        }
+    }
+
     object Light {
         val PRIMARY = Color(0xFF006B5D)
         val PRIMARY_VARIANT = Color(0xFFFFFFFF)

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -3,8 +3,8 @@ package jp.kaleidot725.adbpad.domain.model.language
 import jp.kaleidot725.adbpad.domain.model.language.resources.ChineseResources
 import jp.kaleidot725.adbpad.domain.model.language.resources.EnglishResources
 import jp.kaleidot725.adbpad.domain.model.language.resources.JapaneseResources
-import jp.kaleidot725.adbpad.domain.model.language.resources.TurkishResources
 import jp.kaleidot725.adbpad.domain.model.language.resources.StringResources
+import jp.kaleidot725.adbpad.domain.model.language.resources.TurkishResources
 
 object Language : StringResources {
     override val windowTitle: String

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -1,6 +1,6 @@
 package jp.kaleidot725.adbpad.domain.model.language.resources
 
-val APP_VERSION = "v2.0.2"
+val APP_VERSION = "v2.1.0"
 
 interface StringResources {
     val windowTitle: String

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/CommandTextButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/CommandTextButton.kt
@@ -1,0 +1,50 @@
+package jp.kaleidot725.adbpad.ui.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
+
+@Composable
+fun CommandTextButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit,
+    padding: Dp = 0.dp,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(28.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .clickableBackground(isDarker = true)
+                .clickable { onClick() }
+                .padding(padding),
+    ) {
+        Text(
+            text = text,
+            fontSize = 8.sp,
+            modifier = Modifier.align(Alignment.Center).padding(bottom = 8.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    CommandTextButton(
+        text = "100%",
+        onClick = {},
+    )
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
@@ -162,7 +162,7 @@ class ScreenshotStateHolder(
 
     private suspend fun initPreviews() {
         val screenshots = screenshotCommandRepository.getScreenshots()
-        val screenshot = screenshots.first()
+        val screenshot = screenshots.firstOrNull() ?: Screenshot(null)
         update {
             this.copy(
                 previews = screenshots,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
@@ -1,23 +1,41 @@
 package jp.kaleidot725.adbpad.ui.screen.screenshot.component
 
+import androidx.compose.animation.core.tween
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Minus
+import com.composables.icons.lucide.Plus
+import jp.kaleidot725.adbpad.domain.model.UserColor
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
 import jp.kaleidot725.adbpad.ui.common.resource.defaultBorder
+import jp.kaleidot725.adbpad.ui.component.CommandIconButton
+import jp.kaleidot725.adbpad.ui.component.CommandTextButton
+import kotlinx.coroutines.launch
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 
 @Composable
 fun ScreenshotViewer(
@@ -45,11 +63,91 @@ fun ScreenshotViewer(
             }
         } else {
             if (screenshot.file != null) {
-                AsyncImage(
-                    model = screenshot.file,
-                    contentDescription = null,
+                val zoomState = rememberZoomState()
+                val coroutineScope = rememberCoroutineScope()
+                BoxWithConstraints(
                     modifier = Modifier.fillMaxSize(),
-                )
+                ) {
+                    val constraints = this
+
+                    AsyncImage(
+                        model = screenshot.file,
+                        contentDescription = null,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .clip(RectangleShape)
+                                .zoomable(zoomState),
+                    )
+
+                    Column(
+                        modifier =
+                            Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(12.dp)
+                                .background(
+                                    color = UserColor.getFloatingBackgroundColor(),
+                                    shape = RoundedCornerShape(4.dp),
+                                ),
+                    ) {
+                        CommandIconButton(
+                            image = Lucide.Plus,
+                            onClick = {
+                                coroutineScope.launch {
+                                    zoomState.changeScale(
+                                        targetScale = zoomState.scale + 0.5f,
+                                        position =
+                                            Offset(
+                                                constraints.maxWidth.value / 2f,
+                                                constraints.maxHeight.value / 2f,
+                                            ),
+                                        animationSpec = tween(),
+                                    )
+                                }
+                            },
+                            modifier =
+                                Modifier
+                                    .padding(4.dp)
+                                    .size(32.dp),
+                        )
+
+                        CommandIconButton(
+                            image = Lucide.Minus,
+                            onClick = {
+                                coroutineScope.launch {
+                                    zoomState.changeScale(
+                                        targetScale = zoomState.scale - 0.5f,
+                                        position =
+                                            Offset(
+                                                constraints.maxWidth.value / 2f,
+                                                constraints.maxHeight.value / 2f,
+                                            ),
+                                        animationSpec = tween(),
+                                    )
+                                }
+                            },
+                            modifier =
+                                Modifier
+                                    .padding(4.dp)
+                                    .size(32.dp),
+                        )
+
+                        CommandTextButton(
+                            text = "100%",
+                            onClick = {
+                                coroutineScope.launch {
+                                    coroutineScope.launch {
+                                        zoomState.reset()
+                                    }
+                                }
+                            },
+                            modifier =
+                                Modifier
+                                    .padding(4.dp)
+                                    .size(32.dp),
+                        )
+                    }
+                }
             } else {
                 Box(modifier = Modifier.fillMaxSize()) {
                     Text(


### PR DESCRIPTION
This pull request includes several changes to the `adbpad` project, focusing on adding new features, updating existing components, and improving the user interface. The most important changes are summarized below.

### New Features:
* Added a new `CommandTextButton` component in `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/CommandTextButton.kt` to create a clickable text button with customizable padding and preview functionality.

### User Interface Improvements:
* Enhanced the `ScreenshotViewer` component by adding zoom functionality with `CommandIconButton` and `CommandTextButton` for scaling and resetting the view. This includes importing necessary libraries and modifying the layout to include zoom controls. [[1]](diffhunk://#diff-23c128a81e8443f55b1f342e8d676d5c5b6f136ddf09dd9ae7fb7906759e298dR3-R38) [[2]](diffhunk://#diff-23c128a81e8443f55b1f342e8d676d5c5b6f136ddf09dd9ae7fb7906759e298dR66-R150)
* Introduced a new composable function `getFloatingBackgroundColor` in `UserColor` to dynamically determine the background color based on the theme's light or dark mode.

### Version Updates:
* Updated the application version from `v2.0.2` to `v2.1.0` in `StringResources.kt` to reflect the new release.

### Build Configuration:
* Added a new artifact configuration for `adbpad-jvm-2.1.0` in the `.idea/artifacts/adbpad_jvm_2_1_0.xml` file to specify the output path and module output for the build process.


https://github.com/user-attachments/assets/cd7f5671-3184-49a4-802d-e6dee0f0cb89