### PR TITLE
Feat/add search sort

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -157,6 +157,7 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                 selectCommand = screenshotState.selectedCommand,
                                 commands = screenshotState.commands,
                                 searchText = screenshotState.searchText,
+                                sortType = screenshotState.sortType,
                                 onOpenDirectory = {
                                     onAction(ScreenshotAction.OpenDirectory)
                                 },
@@ -183,6 +184,9 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                 },
                                 onSelectCommand = {
                                     onAction(ScreenshotAction.SelectScreenshotCommand(it))
+                                },
+                                onUpdateSortType = {
+                                    onAction(ScreenshotAction.UpdateSortType(it))
                                 },
                             )
                         }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -20,14 +20,14 @@ import androidx.compose.ui.window.application
 import jp.kaleidot725.adbpad.MainCategory
 import jp.kaleidot725.adbpad.MainStateHolder
 import jp.kaleidot725.adbpad.domain.di.domainModule
-import jp.kaleidot725.adbpad.domain.model.Dialog
-import jp.kaleidot725.adbpad.domain.model.UserColor
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.WindowSize
 import jp.kaleidot725.adbpad.domain.model.setting.getWindowSize
 import jp.kaleidot725.adbpad.repository.di.repositoryModule
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.NavigationRail
 import jp.kaleidot725.adbpad.ui.di.stateHolderModule
+import jp.kaleidot725.adbpad.ui.model.Dialog
 import jp.kaleidot725.adbpad.ui.screen.CommandScreen
 import jp.kaleidot725.adbpad.ui.screen.ScreenLayout
 import jp.kaleidot725.adbpad.ui.screen.command.CommandAction

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainState.kt
@@ -1,9 +1,9 @@
 package jp.kaleidot725.adbpad
 
-import jp.kaleidot725.adbpad.domain.model.Dialog
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.WindowSize
+import jp.kaleidot725.adbpad.ui.model.Dialog
 
 data class MainState(
     val language: Language.Type = Language.Type.ENGLISH,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt
@@ -1,6 +1,5 @@
 package jp.kaleidot725.adbpad
 
-import jp.kaleidot725.adbpad.domain.model.Dialog
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.WindowSize
 import jp.kaleidot725.adbpad.domain.usecase.adb.StartAdbUseCase
@@ -11,6 +10,7 @@ import jp.kaleidot725.adbpad.domain.usecase.window.GetWindowSizeUseCase
 import jp.kaleidot725.adbpad.domain.usecase.window.SaveWindowSizeUseCase
 import jp.kaleidot725.adbpad.ui.common.ChildStateHolder
 import jp.kaleidot725.adbpad.ui.common.ParentStateHolder
+import jp.kaleidot725.adbpad.ui.model.Dialog
 import jp.kaleidot725.adbpad.ui.screen.command.CommandStateHolder
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotStateHolder
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandStateHolder

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -211,6 +211,12 @@ object Language : StringResources {
     override val textCommandOptionTab: String
         get() = getCurrentResources().textCommandOptionTab
 
+    override val sortByNameAsc: String
+        get() = getCurrentResources().sortByNameAsc
+
+    override val sortByNameDesc: String
+        get() = getCurrentResources().sortByNameDesc
+
     private var currentType: Type = Type.ENGLISH
 
     fun switch(type: Type) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -113,4 +113,7 @@ object ChineseResources : StringResources {
     override val adbErrorTitle = "ADB 错误"
     override val adbErrorMessage = "无法启动 ADB 服务，请更改 ADB 设置。"
     override val adbErrorOpenSetting = "打开设置"
+
+    override val sortByNameAsc: String = "名稱(升序)"
+    override val sortByNameDesc: String = "名稱(降序)"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -113,4 +113,7 @@ object EnglishResources : StringResources {
     override val adbErrorTitle = "Adb Error"
     override val adbErrorMessage = "Can't start adb server, Please change adb setting."
     override val adbErrorOpenSetting = "Open Setting"
+
+    override val sortByNameAsc: String = "Name(Asc)"
+    override val sortByNameDesc: String = "Name(Desc)"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -112,4 +112,7 @@ object JapaneseResources : StringResources {
     override val adbErrorTitle = "ADBエラー"
     override val adbErrorMessage = "ADBサーバーを開始できませんでした、ADBの設定を変更してください"
     override val adbErrorOpenSetting = "設定を開く"
+
+    override val sortByNameAsc: String = "名前(昇順)"
+    override val sortByNameDesc: String = "名前(降順)"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -32,7 +32,6 @@ interface StringResources {
     val commandStartEventFormat: String
     val commandEndEventFormat: String
     val commandErrorEventFormat: String
-
     val commandPointerLocationOnTitle: String
     val commandPointerLocationOnDetails: String
     val commandPointerLocationOffTitle: String
@@ -94,13 +93,11 @@ interface StringResources {
     val menuScreenshot: String
 
     val settingAppearanceHeader: String
-
     val settingLanguageHeader: String
     val settingLanguageEnglish: String
     val settingLanguageJapanese: String
     val settingLanguageChinese: String
     val settingLanguageTurkish: String
-
     val settingAdbHeader: String
     val settingAdbDirectoryPathTitle: String
     val settingAdbPortNumberTitle: String
@@ -114,4 +111,7 @@ interface StringResources {
 
     val textCommandOptionNewLine: String
     val textCommandOptionTab: String
+
+    val sortByNameAsc: String
+    val sortByNameDesc: String
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -113,4 +113,7 @@ object TurkishResources : StringResources {
     override val adbErrorTitle = "Adb Hatası"
     override val adbErrorMessage = "Adb sunucusu başlatılamıyor, lütfen adb ayarlarını değiştirin."
     override val adbErrorOpenSetting = "Ayarları Aç"
+
+    override val sortByNameAsc: String = "İsim (artan sıra)"
+    override val sortByNameDesc: String = " İsim (azalan sıra)"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/sort/SortType.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/sort/SortType.kt
@@ -1,0 +1,6 @@
+package jp.kaleidot725.adbpad.domain.model.sort
+
+enum class SortType {
+    SORT_BY_NAME_ASC,
+    SORT_BY_NAME_DESC,
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/repository/ScreenshotCommandRepository.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/repository/ScreenshotCommandRepository.kt
@@ -3,6 +3,7 @@ package jp.kaleidot725.adbpad.domain.repository
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 
 interface ScreenshotCommandRepository {
     fun getCommands(): List<ScreenshotCommand>
@@ -15,7 +16,10 @@ interface ScreenshotCommandRepository {
         onFailed: suspend () -> Unit,
     )
 
-    suspend fun getScreenshots(): List<Screenshot>
+    suspend fun getScreenshots(
+        searchText: String,
+        sortType: SortType,
+    ): List<Screenshot>
 
     suspend fun delete(screenshot: Screenshot)
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/text/GetTextCommandUseCase.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/text/GetTextCommandUseCase.kt
@@ -1,10 +1,21 @@
 package jp.kaleidot725.adbpad.domain.usecase.text
 
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.domain.repository.TextCommandRepository
 
-class GetTextCommandUseCase(private val textCommandRepository: TextCommandRepository) {
-    suspend operator fun invoke(): List<TextCommand> {
-        return textCommandRepository.getAllTextCommand()
+class GetTextCommandUseCase(
+    private val textCommandRepository: TextCommandRepository,
+) {
+    suspend operator fun invoke(
+        searchText: String,
+        sortType: SortType,
+    ): List<TextCommand> {
+        val commands = textCommandRepository.getAllTextCommand()
+        val filteredCommands = commands.filter { it.title.startsWith(searchText) }
+        return when (sortType) {
+            SortType.SORT_BY_NAME_ASC -> filteredCommands.sortedBy { it.title }
+            SortType.SORT_BY_NAME_DESC -> filteredCommands.sortedByDescending { it.title }
+        }
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/Color.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/Color.kt
@@ -17,16 +17,15 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.unit.dp
-import jp.kaleidot725.adbpad.domain.model.UserColor.getSplitterColor
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor.getSplitterColor
 
 @Composable
-fun Modifier.selectedBackground(isSelected: Boolean): Modifier {
-    return if (isSelected) {
+fun Modifier.selectedBackground(isSelected: Boolean): Modifier =
+    if (isSelected) {
         this.background(color = MaterialTheme.colors.primary.copy(alpha = 0.2f))
     } else {
         this
     }
-}
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -61,6 +60,4 @@ fun Modifier.clickableBackground(
 }
 
 @Composable
-fun Modifier.defaultBorder(): Modifier {
-    return this.border(shape = RoundedCornerShape(8.dp), color = getSplitterColor(), width = 1.dp)
-}
+fun Modifier.defaultBorder(): Modifier = this.border(shape = RoundedCornerShape(8.dp), color = getSplitterColor(), width = 1.dp)

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/UserColor.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/UserColor.kt
@@ -1,4 +1,4 @@
-package jp.kaleidot725.adbpad.domain.model
+package jp.kaleidot725.adbpad.ui.common.resource
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/SearchSortDropBox.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/SearchSortDropBox.kt
@@ -1,0 +1,121 @@
+package jp.kaleidot725.adbpad.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
+import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
+
+@Composable
+fun SearchSortDropBox(
+    selectedSortType: SortType,
+    onSelectType: (SortType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier) {
+        Box(
+            modifier =
+                Modifier
+                    .padding(vertical = 4.dp, horizontal = 4.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickableBackground(isDarker = !MaterialTheme.colors.isLight)
+                    .clickable {
+                        expanded = true
+                    }.width(40.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .offset(x = (-6).dp)
+                        .padding(vertical = 8.dp)
+                        .size(24.dp),
+            )
+
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = "Device DropDown Icon",
+                tint = MaterialTheme.colors.onBackground,
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .offset(x = 10.dp)
+                        .size(24.dp),
+            )
+        }
+    }
+
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+    ) {
+        SortType.entries.forEach { sortType ->
+            DropdownMenuItem(
+                onClick = {
+                    expanded = false
+                    onSelectType(sortType)
+                },
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(24.dp)
+                                .align(Alignment.CenterVertically),
+                    ) {
+                        if (selectedSortType == sortType) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = "Check",
+                                tint = MaterialTheme.colors.onBackground,
+                                modifier = Modifier.align(Alignment.Center).size(20.dp),
+                            )
+                        }
+                    }
+
+                    Text(
+                        text =
+                            when (sortType) {
+                                SortType.SORT_BY_NAME_ASC -> Language.sortByNameAsc
+                                SortType.SORT_BY_NAME_DESC -> Language.sortByNameDesc
+                            },
+                        color = MaterialTheme.colors.onBackground,
+                        style = MaterialTheme.typography.subtitle2,
+                        modifier = Modifier.align(Alignment.CenterVertically).padding(bottom = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/layout/ScreenLayout.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/layout/ScreenLayout.kt
@@ -17,7 +17,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import jp.kaleidot725.adbpad.domain.model.UserColor
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 
 @Composable
 fun ScreenLayout(

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/model/Dialog.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/model/Dialog.kt
@@ -1,4 +1,4 @@
-package jp.kaleidot725.adbpad.domain.model
+package jp.kaleidot725.adbpad.ui.model
 
 sealed class Dialog {
     object Setting : Dialog()

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/menu/component/DropDownDeviceMenu.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/menu/component/DropDownDeviceMenu.kt
@@ -41,7 +41,7 @@ fun DropDownDeviceMenu(
                 Modifier
                     .wrapContentSize()
                     .clip(RoundedCornerShape(4.dp))
-                    .clickableBackground(isDarker = true)
+                    .clickableBackground(isDarker = !MaterialTheme.colors.isLight)
                     .clickable { if (!expanded && devices.isNotEmpty()) expanded = true }
                     .onSizeChanged { dropDownWidth = it.width },
         )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotAction.kt
@@ -3,10 +3,15 @@ package jp.kaleidot725.adbpad.ui.screen.screenshot
 import jp.kaleidot725.adbpad.core.mvi.MVIAction
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 
 sealed class ScreenshotAction : MVIAction {
     data class UpdateSearchText(
         val text: String,
+    ) : ScreenshotAction()
+
+    data class UpdateSortType(
+        val sortType: SortType,
     ) : ScreenshotAction()
 
     data class SelectScreenshotCommand(

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
@@ -77,6 +77,7 @@ fun ScreenshotScreen(
                         sortType = sortType,
                         onUpdateSortType = onUpdateSortType,
                         onUpdateSearchText = onUpdateSearchText,
+                        onDelete = onDeleteScreenshot,
                         modifier = Modifier,
                     )
 
@@ -100,7 +101,6 @@ fun ScreenshotScreen(
                         isCapturing = isCapturing,
                         onOpenDirectory = onOpenDirectory,
                         onCopyScreenshot = onCopyScreenshot,
-                        onDeleteScreenshot = onDeleteScreenshot,
                         modifier =
                             Modifier
                                 .weight(1.0f)

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
-import jp.kaleidot725.adbpad.domain.model.UserColor
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.defaultBorder
 import jp.kaleidot725.adbpad.ui.screen.screenshot.component.ScreenshotExplorer
 import jp.kaleidot725.adbpad.ui.screen.screenshot.component.ScreenshotHeader

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.defaultBorder
 import jp.kaleidot725.adbpad.ui.screen.screenshot.component.ScreenshotExplorer
@@ -46,6 +47,7 @@ fun ScreenshotScreen(
     selectCommand: ScreenshotCommand,
     commands: List<ScreenshotCommand>,
     searchText: String,
+    sortType: SortType,
     onOpenDirectory: () -> Unit,
     onCopyScreenshot: () -> Unit,
     onDeleteScreenshot: () -> Unit,
@@ -55,6 +57,7 @@ fun ScreenshotScreen(
     onNextScreenshot: () -> Unit,
     onPreviousScreenshot: () -> Unit,
     onUpdateSearchText: (String) -> Unit,
+    onUpdateSortType: (SortType) -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -71,6 +74,8 @@ fun ScreenshotScreen(
                 Column {
                     ScreenshotHeader(
                         searchText = searchText,
+                        sortType = sortType,
+                        onUpdateSortType = onUpdateSortType,
                         onUpdateSearchText = onUpdateSearchText,
                         modifier = Modifier,
                     )
@@ -152,6 +157,7 @@ private fun ScreenshotScreen_Preview() {
         selectCommand = ScreenshotCommand.Both,
         commands = emptyList(),
         searchText = "",
+        sortType = SortType.SORT_BY_NAME_ASC,
         onOpenDirectory = {},
         onCopyScreenshot = {},
         onDeleteScreenshot = {},
@@ -161,5 +167,6 @@ private fun ScreenshotScreen_Preview() {
         onPreviousScreenshot = {},
         onUpdateSearchText = {},
         onSelectCommand = {},
+        onUpdateSortType = {},
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotState.kt
@@ -4,6 +4,7 @@ import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 
 data class ScreenshotState(
     val searchText: String = "",
@@ -13,6 +14,7 @@ data class ScreenshotState(
     val commands: List<ScreenshotCommand> = emptyList(),
     val selectedDevice: Device? = null,
     val isCapturing: Boolean = false,
+    val sortType: SortType = SortType.SORT_BY_NAME_ASC,
 ) : MVIState {
     val canExecute: Boolean = selectedDevice != null
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FileCopy
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.runtime.Composable
@@ -28,30 +27,12 @@ fun ScreenshotActions(
     enabled: Boolean,
     onOpen: () -> Unit,
     onCopy: () -> Unit,
-    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier,
     ) {
-        IconButton(
-            onClick = onOpen,
-            enabled = enabled,
-            modifier =
-                Modifier
-                    .padding(vertical = 4.dp)
-                    .size(32.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .align(Alignment.CenterVertically),
-        ) {
-            Icon(
-                imageVector = Icons.Default.FileOpen,
-                contentDescription = "copy",
-                modifier = Modifier.height(20.dp),
-            )
-        }
-
         IconButton(
             onClick = onCopy,
             enabled = enabled,
@@ -70,7 +51,7 @@ fun ScreenshotActions(
         }
 
         IconButton(
-            onClick = onDelete,
+            onClick = onOpen,
             enabled = enabled,
             modifier =
                 Modifier
@@ -80,8 +61,8 @@ fun ScreenshotActions(
                     .align(Alignment.CenterVertically),
         ) {
             Icon(
-                imageVector = Icons.Default.Delete,
-                contentDescription = "delete",
+                imageVector = Icons.Default.FileOpen,
+                contentDescription = "copy",
                 modifier = Modifier.height(20.dp),
             )
         }
@@ -95,7 +76,6 @@ private fun ScreenshotHeader_Preview() {
         enabled = true,
         onOpen = {},
         onCopy = {},
-        onDelete = {},
         modifier =
             Modifier
                 .fillMaxWidth()

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotHeader.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotHeader.kt
@@ -2,28 +2,26 @@ package jp.kaleidot725.adbpad.ui.screen.screenshot.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.component.DefaultTextField
+import jp.kaleidot725.adbpad.ui.component.SearchSortDropBox
 
 @Composable
 fun ScreenshotHeader(
     searchText: String,
+    sortType: SortType,
+    onUpdateSortType: (SortType) -> Unit,
     onUpdateSearchText: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier) {
-        Icon(
-            imageVector = Icons.Default.Search,
-            contentDescription = null,
-            modifier = Modifier.align(Alignment.CenterVertically).padding(12.dp),
+        SearchSortDropBox(
+            selectedSortType = sortType,
+            onSelectType = onUpdateSortType,
         )
 
         DefaultTextField(
@@ -40,6 +38,8 @@ fun ScreenshotHeader(
 private fun Preview() {
     ScreenshotHeader(
         searchText = "TEST",
+        sortType = SortType.SORT_BY_NAME_ASC,
+        onUpdateSortType = {},
         onUpdateSearchText = {},
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotHeader.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotHeader.kt
@@ -2,9 +2,21 @@ package jp.kaleidot725.adbpad.ui.screen.screenshot.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.component.DefaultTextField
@@ -16,6 +28,7 @@ fun ScreenshotHeader(
     sortType: SortType,
     onUpdateSortType: (SortType) -> Unit,
     onUpdateSearchText: (String) -> Unit,
+    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier) {
@@ -30,6 +43,24 @@ fun ScreenshotHeader(
             placeHolder = Language.search,
             modifier = Modifier.align(Alignment.CenterVertically).weight(1.0f),
         )
+
+        IconButton(
+            onClick = onDelete,
+            modifier =
+                Modifier
+                    .padding(vertical = 4.dp)
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .align(Alignment.CenterVertically),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = "delete",
+                modifier = Modifier.height(20.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
     }
 }
 
@@ -41,5 +72,6 @@ private fun Preview() {
         sortType = SortType.SORT_BY_NAME_ASC,
         onUpdateSortType = {},
         onUpdateSearchText = {},
+        onDelete = {},
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
@@ -43,7 +43,6 @@ fun ScreenshotViewer(
     isCapturing: Boolean,
     onOpenDirectory: () -> Unit,
     onCopyScreenshot: () -> Unit,
-    onDeleteScreenshot: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -51,7 +50,6 @@ fun ScreenshotViewer(
             enabled = screenshot.file != null,
             onOpen = onOpenDirectory,
             onCopy = onCopyScreenshot,
-            onDelete = onDeleteScreenshot,
             modifier = Modifier.height(48.dp).padding(horizontal = 12.dp).align(Alignment.End),
         )
 
@@ -168,7 +166,6 @@ private fun ScreenshotViewer_Preview() {
         isCapturing = false,
         onOpenDirectory = {},
         onCopyScreenshot = {},
-        onDeleteScreenshot = {},
         modifier = Modifier.fillMaxSize(),
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
@@ -27,9 +27,9 @@ import coil3.compose.AsyncImage
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Minus
 import com.composables.icons.lucide.Plus
-import jp.kaleidot725.adbpad.domain.model.UserColor
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.screenshot.Screenshot
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.defaultBorder
 import jp.kaleidot725.adbpad.ui.component.CommandIconButton
 import jp.kaleidot725.adbpad.ui.component.CommandTextButton

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandAction.kt
@@ -2,6 +2,7 @@ package jp.kaleidot725.adbpad.ui.screen.text
 
 import jp.kaleidot725.adbpad.core.mvi.MVIAction
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 
 sealed class TextCommandAction : MVIAction {
     data class UpdateSearchText(
@@ -9,6 +10,10 @@ sealed class TextCommandAction : MVIAction {
     ) : TextCommandAction()
 
     data object AddNewText : TextCommandAction()
+
+    data class UpdateSortType(
+        val type: SortType,
+    ) : TextCommandAction()
 
     data class UpdateCommandTitle(
         val id: String,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
@@ -44,6 +44,8 @@ fun TextCommandScreen(
             Column {
                 TextCommandHeader(
                     searchText = state.searchText,
+                    sortType = state.sortType,
+                    onUpdateSortType = { onAction(TextCommandAction.UpdateSortType(it)) },
                     onUpdateSearchText = { onAction(TextCommandAction.UpdateSearchText(it)) },
                     onAddNewTextCommand = { onAction(TextCommandAction.AddNewText) },
                 )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
@@ -48,6 +48,7 @@ fun TextCommandScreen(
                     onUpdateSortType = { onAction(TextCommandAction.UpdateSortType(it)) },
                     onUpdateSearchText = { onAction(TextCommandAction.UpdateSearchText(it)) },
                     onAddNewTextCommand = { onAction(TextCommandAction.AddNewText) },
+                    onDelete = { onAction(TextCommandAction.DeleteSelectedCommandText) },
                 )
 
                 Divider(modifier = Modifier.fillMaxWidth().defaultBorder())
@@ -70,7 +71,6 @@ fun TextCommandScreen(
                         command = state.selectedCommand,
                         onUpdateTitle = { id, title -> onAction(TextCommandAction.UpdateCommandTitle(id, title)) },
                         onUpdateText = { id, text -> onAction(TextCommandAction.UpdateCommandText(id, text)) },
-                        onDelete = { onAction(TextCommandAction.DeleteSelectedCommandText) },
                     )
 
                     Spacer(

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import jp.kaleidot725.adbpad.domain.model.UserColor
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.defaultBorder
 import jp.kaleidot725.adbpad.ui.screen.screenshot.cursorForHorizontalResize
 import jp.kaleidot725.adbpad.ui.screen.text.component.TextCommandActions

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandState.kt
@@ -3,17 +3,19 @@ package jp.kaleidot725.adbpad.ui.screen.text
 import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 
 data class TextCommandState(
-    val selectedCommandIndex: Int? = null,
+    val selectedCommandId: String? = null,
     val commands: List<TextCommand> = emptyList(),
     val userInputText: String = "",
     val isSendingUserInputText: Boolean = false,
     val selectedDevice: Device? = null,
     val isSendingTab: Boolean = false,
     val searchText: String = "",
+    val sortType: SortType = SortType.SORT_BY_NAME_ASC,
     val selectedTextCommandOption: TextCommand.Option = TextCommand.Option.SendWithTab,
 ) : MVIState {
-    val selectedCommand: TextCommand? = commands.getOrNull(selectedCommandIndex ?: 0)
+    val selectedCommand: TextCommand? = commands.firstOrNull { it.id == selectedCommandId }
     val canSend: Boolean = selectedDevice != null
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandStateHolder.kt
@@ -221,14 +221,24 @@ class TextCommandStateHolder(
                 searchText = currentState.searchText,
                 sortType = currentState.sortType,
             )
-        val newSelectedCommand = commands.getOrNull(selectedCommandIndex)
-        val newSelectedCommandIndex = if (newSelectedCommand == null) commands.lastIndex else selectedCommandIndex
-        val newSelectedCommandId = commands[newSelectedCommandIndex].id
-        update {
-            copy(
-                commands = commands,
-                selectedCommandId = newSelectedCommandId,
-            )
+
+        if (commands.isEmpty()) {
+            update {
+                copy(
+                    commands = commands,
+                    selectedCommandId = null,
+                )
+            }
+        } else {
+            val newSelectedCommand = commands.getOrNull(selectedCommandIndex)
+            val newSelectedCommandIndex = if (newSelectedCommand == null) commands.lastIndex else selectedCommandIndex
+            val newSelectedCommandId = commands[newSelectedCommandIndex].id
+            update {
+                copy(
+                    commands = commands,
+                    selectedCommandId = newSelectedCommandId,
+                )
+            }
         }
     }
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt
@@ -7,10 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,7 +21,6 @@ fun TextCommandEditor(
     command: TextCommand,
     onUpdateTitle: (id: String, value: String) -> Unit,
     onUpdateText: (id: String, value: String) -> Unit,
-    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -39,15 +34,6 @@ fun TextCommandEditor(
                 onUpdateText = { onUpdateTitle(command.id, it) },
                 modifier = Modifier.weight(1.0f).height(48.dp).padding(horizontal = 12.dp),
             )
-
-            IconButton(
-                onClick = onDelete,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = "",
-                )
-            }
         }
 
         Divider(modifier = Modifier.height(1.dp).fillMaxWidth().defaultBorder())
@@ -70,6 +56,5 @@ private fun Preview() {
         command = TextCommandDummy.value,
         onUpdateTitle = { _, _ -> },
         onUpdateText = { _, _ -> },
-        onDelete = {},
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandHeader.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandHeader.kt
@@ -2,31 +2,31 @@ package jp.kaleidot725.adbpad.ui.screen.text.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.component.DefaultTextField
+import jp.kaleidot725.adbpad.ui.component.SearchSortDropBox
 
 @Composable
 fun TextCommandHeader(
     searchText: String,
+    sortType: SortType,
+    onUpdateSortType: (SortType) -> Unit,
     onUpdateSearchText: (String) -> Unit,
     onAddNewTextCommand: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier) {
-        Icon(
-            imageVector = Icons.Default.Search,
-            contentDescription = null,
-            modifier = Modifier.align(Alignment.CenterVertically).padding(12.dp),
+        SearchSortDropBox(
+            selectedSortType = sortType,
+            onSelectType = onUpdateSortType,
         )
 
         DefaultTextField(
@@ -49,6 +49,8 @@ fun TextCommandHeader(
 private fun Preview() {
     TextCommandHeader(
         searchText = "TEST",
+        sortType = SortType.SORT_BY_NAME_ASC,
+        onUpdateSortType = {},
         onUpdateSearchText = {},
         onAddNewTextCommand = {},
     )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandHeader.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandHeader.kt
@@ -2,13 +2,22 @@ package jp.kaleidot725.adbpad.ui.screen.text.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.component.DefaultTextField
@@ -21,6 +30,7 @@ fun TextCommandHeader(
     onUpdateSortType: (SortType) -> Unit,
     onUpdateSearchText: (String) -> Unit,
     onAddNewTextCommand: () -> Unit,
+    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(modifier) {
@@ -38,9 +48,37 @@ fun TextCommandHeader(
 
         IconButton(
             onClick = onAddNewTextCommand,
+            modifier =
+                Modifier
+                    .padding(vertical = 4.dp)
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .align(Alignment.CenterVertically),
         ) {
-            Icon(imageVector = Icons.Default.Add, contentDescription = null)
+            Icon(
+                imageVector = Icons.Default.Create,
+                contentDescription = "create",
+                modifier = Modifier.height(20.dp),
+            )
         }
+
+        IconButton(
+            onClick = onDelete,
+            modifier =
+                Modifier
+                    .padding(vertical = 4.dp)
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .align(Alignment.CenterVertically),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Delete,
+                contentDescription = "delete",
+                modifier = Modifier.height(20.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
     }
 }
 
@@ -53,5 +91,6 @@ private fun Preview() {
         onUpdateSortType = {},
         onUpdateSearchText = {},
         onAddNewTextCommand = {},
+        onDelete = {},
     )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/TopSection.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/TopSection.kt
@@ -53,7 +53,7 @@ fun TopSection(
         modifier = Modifier.fillMaxWidth().height(40.dp),
     ) {
         Box {
-            Row(Modifier.align(Alignment.CenterStart).wrapContentSize()) {
+            Row(Modifier.align(Alignment.CenterStart).wrapContentSize().padding(start = 4.dp)) {
                 DropDownDeviceMenu(
                     devices = state.devices,
                     selectedDevice = state.selectedDevice,


### PR DESCRIPTION
This pull request introduces several significant changes to the `adbpad` project, focusing on refactoring imports, adding new sorting functionality, and updating language resources. Here are the most important changes:

### Refactoring Imports
* Moved the `Dialog` and `UserColor` models from the `domain.model` package to the `ui.model` and `ui.common.resource` packages, respectively. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainState.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/common/resource/Color.kt`) [[1]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4L23-R30) [[2]](diffhunk://#diff-da8768f4f66b1e242293f63c62bfdcd6473bf965b35fe3fb6537b62b3e74c3f1L3-R6) [[3]](diffhunk://#diff-3ee8f2f735349543d993deb5a25ba170136f40f9b5abdf00ff70710e408e8fd0L3) [[4]](diffhunk://#diff-450e508ff94d75c8dc074bf9bb88d497b581ff8b0d23121e399c8dce1631dc0eL20-L29)

### Adding Sorting Functionality
* Introduced a new `SortType` enum to handle sorting by name in ascending and descending order. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/sort/SortType.kt`)
* Updated the `ScreenshotCommandRepository` and its implementation to support sorting screenshots based on the new `SortType`. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/repository/ScreenshotCommandRepository.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/repository/impl/ScreenshotCommandRepositoryImpl.kt`) [[1]](diffhunk://#diff-2a011d4638583701f877b12f1ee81f672d2f181187d16213f65c2f4b2b0f26ceL18-R22) [[2]](diffhunk://#diff-7e4c7dd8f1da6c28fbf2c74974bd6a62b46da0cb05b8fb0f3ec5ac4330275b47L63-R83)
* Enhanced the `GetTextCommandUseCase` to filter and sort text commands based on user input. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/usecase/text/GetTextCommandUseCase.kt`)

### UI Enhancements
* Added a new `SearchSortDropBox` component to allow users to select the sort type from a dropdown menu. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/SearchSortDropBox.kt`)
* Updated the `App` function in `Main.kt` to handle the new sort type and provide corresponding actions. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt`) [[1]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4R160) [[2]](diffhunk://#diff-3bda61a6ecdd82c58078d7c96c3ffb5faea7ea9d1363c920c9bc55ebe23a49b4R188-R190)

### Language Resource Updates
* Added new language resources for sorting by name in ascending and descending order across multiple languages (Chinese, English, Japanese, Turkish). (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt`, `src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt`) [[1]](diffhunk://#diff-594031841b8fb02bbafe5d12494fb8440c913435b2df7a53e2b3da6c72e4369eR116-R118) [[2]](diffhunk://#diff-ed0f482c0e642d8cb3cb91655707c86d2bfedd893b4d0a6c2c21f35122c6437fR116-R118) [[3]](diffhunk://#diff-2477d85a4cf96726bf08ddb8fd0be90e659bbad751dffc081d24cdd549b6c7f3R115-R117) [[4]](diffhunk://#diff-b35228af6b444eabcaa2b8f89dd8fd4c85531ac2a27b8b37ab0ba12f623d7051R116-R118)
* Updated the `StringResources` interface to include the new sort type strings. (`src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt`)

These changes collectively improve the code organization, add new functionality for sorting, and enhance the user interface and language support.


https://github.com/user-attachments/assets/d7d43d4f-4a3d-41aa-a620-8968bcd51491

