### PR TITLE
feat: add newline and tab text to editor line

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt
@@ -69,6 +69,7 @@ fun TextCommandScreen(
                 if (state.selectedCommand != null) {
                     TextCommandEditor(
                         command = state.selectedCommand,
+                        option = state.selectedTextCommandOption,
                         onUpdateTitle = { id, title -> onAction(TextCommandAction.UpdateCommandTitle(id, title)) },
                         onUpdateText = { id, text -> onAction(TextCommandAction.UpdateCommandText(id, text)) },
                     )


### PR DESCRIPTION
## Summary

This pull request includes several changes to the `TextCommandEditor` component in the `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text` directory. The changes primarily focus on adding a new `option` parameter to the `TextCommandEditor` and implementing a custom visual transformation for text input.

Key changes include:

### Addition of `option` parameter:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandScreen.kt`](diffhunk://#diff-489eb786451446cbebb4417bc2d8a691fcea3f0300ee92c89c96d41f46985550R72): Added `option` parameter to the `TextCommandEditor` call.
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt`](diffhunk://#diff-009a8789e3e2173440c9d245255eb1d40e33b2178aa90c7234c008bf61b0a857R38): Added `option` parameter to the `TextCommandEditor` function signature.

### Implementation of custom visual transformation:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt`](diffhunk://#diff-009a8789e3e2173440c9d245255eb1d40e33b2178aa90c7234c008bf61b0a857L41-R72): Replaced `DefaultTextField` with `BasicTextField` and implemented `LineBreakTransformation` for custom visual transformation based on the `option` parameter. [[1]](diffhunk://#diff-009a8789e3e2173440c9d245255eb1d40e33b2178aa90c7234c008bf61b0a857L41-R72) [[2]](diffhunk://#diff-009a8789e3e2173440c9d245255eb1d40e33b2178aa90c7234c008bf61b0a857R83-R135)

### Import statements update:
* [`src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt`](diffhunk://#diff-009a8789e3e2173440c9d245255eb1d40e33b2178aa90c7234c008bf61b0a857R9-R28): Added necessary import statements for `BasicTextField`, `MaterialTheme`, and other related components.

## Screenshots

![スクリーンショット 2025-03-21 21 44 13](https://github.com/user-attachments/assets/48851aef-c7e0-44f7-b4bb-4198e514071a)

![スクリーンショット 2025-03-21 21 44 17](https://github.com/user-attachments/assets/19f6450c-3e51-419b-812c-ab74486b98ea)
