### PR TITLE
fix: change device drop down menu width

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DeviceSelector.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DeviceSelector.kt
@@ -1,10 +1,14 @@
 package jp.kaleidot725.adbpad.ui.section.top.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -17,16 +21,24 @@ import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.device.DeviceState
 import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
 
 @Composable
 fun DeviceSelector(
     selectedDevice: Device?,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier =
+                Modifier
+                    .widthIn(150.dp)
+                    .clickableBackground(isDarker = !MaterialTheme.colors.isLight)
+                    .clickable(onClick = onClick)
+                    .padding(horizontal = 8.dp)
+                    .padding(bottom = 4.dp),
         ) {
             Text(
                 text = selectedDevice?.displayName ?: Language.notFoundDevice,
@@ -34,6 +46,8 @@ fun DeviceSelector(
                 color = MaterialTheme.colors.onBackground,
                 modifier = Modifier.align(Alignment.CenterVertically),
             )
+
+            Spacer(modifier = Modifier.width(4.dp))
 
             Icon(
                 imageVector = Icons.Filled.ArrowDropDown,
@@ -49,5 +63,8 @@ fun DeviceSelector(
 @Composable
 private fun SelectedDevice_Preview() {
     val sample = Device("DEVICE", "NAME", DeviceState.DEVICE)
-    DeviceSelector(selectedDevice = sample)
+    DeviceSelector(
+        selectedDevice = sample,
+        onClick = {},
+    )
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DropDownDeviceMenu.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DropDownDeviceMenu.kt
@@ -1,7 +1,6 @@
 package jp.kaleidot725.adbpad.ui.section.top.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +8,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DropdownMenu
@@ -31,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.device.DeviceState
 import jp.kaleidot725.adbpad.domain.model.language.Language
-import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
 import jp.kaleidot725.adbpad.ui.component.button.CommandIconButton
 
 @Composable
@@ -48,19 +47,18 @@ fun DropDownDeviceMenu(
     Box(modifier) {
         DeviceSelector(
             selectedDevice = selectedDevice,
+            onClick = { if (!expanded && devices.isNotEmpty()) expanded = true },
             modifier =
                 Modifier
                     .wrapContentSize()
                     .clip(RoundedCornerShape(4.dp))
-                    .clickableBackground(isDarker = !MaterialTheme.colors.isLight)
-                    .clickable { if (!expanded && devices.isNotEmpty()) expanded = true }
                     .onSizeChanged { dropDownWidth = it.width },
         )
 
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.width(with(LocalDensity.current) { dropDownWidth.toDp() }),
+            modifier = Modifier.widthIn(min = with(LocalDensity.current) { dropDownWidth.toDp() }),
         ) {
             Row(
                 modifier = Modifier.height(22.dp).padding(start = 16.dp, end = 8.dp),


### PR DESCRIPTION
## Summary

This pull request includes changes to the `DeviceSelector` and `DropDownDeviceMenu` components to improve their layout and interactivity. The most important changes include adding a click handler to the `DeviceSelector`, adjusting layout spacing and padding, and modifying the `DropDownDeviceMenu` to use `widthIn` instead of `width`.

Improvements to `DeviceSelector` component:

* Added `clickable` and `clickableBackground` modifiers to the `DeviceSelector` component to handle click events.
* Adjusted the layout by changing `horizontalArrangement` to `Arrangement.SpaceBetween` and modifying padding values.
* Included a `Spacer` with a width of `4.dp` between the `Text` and `Icon` elements for better spacing.
* Updated `SelectedDevice_Preview` to include the new `onClick` parameter.

Improvements to `DropDownDeviceMenu` component:

* Removed `clickable` and `clickableBackground` modifiers, as the click handling is now managed by the `DeviceSelector` component. [[1]](diffhunk://#diff-cb61a06f30a737e24902fd50037eb12b068a06864d50de9b112a843907a33316L34) [[2]](diffhunk://#diff-cb61a06f30a737e24902fd50037eb12b068a06864d50de9b112a843907a33316R50-R61)
* Changed the `width` modifier to `widthIn` for the `DropdownMenu` to ensure minimum width constraints are respected.

## Screenshot

![image](https://github.com/user-attachments/assets/2b97cad5-6144-43ff-bbc4-97d31f10c745)
