### PR TITLE
feat: fix icon and component

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -29,12 +30,13 @@ import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.rail.NavigationRail
 import jp.kaleidot725.adbpad.ui.screen.CommandScreen
 import jp.kaleidot725.adbpad.ui.screen.ScreenLayout
-import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction
+import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction.*
 import jp.kaleidot725.adbpad.ui.screen.device.DeviceScreen
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSideEffect
 import jp.kaleidot725.adbpad.ui.screen.error.AdbErrorScreen
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotScreen
 import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotAction
+import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotAction.*
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingScreen
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingStateHolder
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingAction
@@ -133,9 +135,9 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                             CommandScreen(
                                 commands = commandState.commands,
                                 filtered = commandState.filtered,
-                                onClickFilter = { commandAction(CommandAction.ClickCategoryTab(it)) },
+                                onClickFilter = { commandAction(ClickCategoryTab(it)) },
                                 canExecute = commandState.canExecuteCommand,
-                                onExecute = { command -> commandAction(CommandAction.ExecuteCommand(command)) },
+                                onExecute = { command -> commandAction(ExecuteCommand(command)) },
                             )
                         }
 
@@ -174,10 +176,10 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                     onAction(ScreenshotAction.DeleteScreenshotToClipboard)
                                 },
                                 onTakeScreenshot = { screenshot ->
-                                    onAction(ScreenshotAction.TakeScreenshot(screenshot))
+                                    onAction(TakeScreenshot(screenshot))
                                 },
                                 onSelectScreenshot = { screenshot ->
-                                    onAction(ScreenshotAction.SelectScreenshot(screenshot))
+                                    onAction(SelectScreenshot(screenshot))
                                 },
                                 onNextScreenshot = {
                                     onAction(ScreenshotAction.NextScreenshot)
@@ -186,15 +188,18 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                     onAction(ScreenshotAction.PreviousScreenshot)
                                 },
                                 onUpdateSearchText = {
-                                    onAction(ScreenshotAction.UpdateSearchText(it))
+                                    onAction(UpdateSearchText(it))
                                 },
                                 onSelectCommand = {
-                                    onAction(ScreenshotAction.SelectScreenshotCommand(it))
+                                    onAction(SelectScreenshotCommand(it))
                                 },
                                 onUpdateSortType = {
-                                    onAction(ScreenshotAction.UpdateSortType(it))
+                                    onAction(UpdateSortType(it))
                                 },
                             )
+                        }
+                        MainCategory.File -> {
+                            Text("TEST")
                         }
                     }
                 },

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -30,13 +30,12 @@ import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.rail.NavigationRail
 import jp.kaleidot725.adbpad.ui.screen.CommandScreen
 import jp.kaleidot725.adbpad.ui.screen.ScreenLayout
-import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction.*
+import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction
 import jp.kaleidot725.adbpad.ui.screen.device.DeviceScreen
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSideEffect
 import jp.kaleidot725.adbpad.ui.screen.error.AdbErrorScreen
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotScreen
 import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotAction
-import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotAction.*
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingScreen
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingStateHolder
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingAction
@@ -135,9 +134,9 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                             CommandScreen(
                                 commands = commandState.commands,
                                 filtered = commandState.filtered,
-                                onClickFilter = { commandAction(ClickCategoryTab(it)) },
+                                onClickFilter = { commandAction(CommandAction.ClickCategoryTab(it)) },
                                 canExecute = commandState.canExecuteCommand,
-                                onExecute = { command -> commandAction(ExecuteCommand(command)) },
+                                onExecute = { command -> commandAction(CommandAction.ExecuteCommand(command)) },
                             )
                         }
 
@@ -176,10 +175,10 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                     onAction(ScreenshotAction.DeleteScreenshotToClipboard)
                                 },
                                 onTakeScreenshot = { screenshot ->
-                                    onAction(TakeScreenshot(screenshot))
+                                    onAction(ScreenshotAction.TakeScreenshot(screenshot))
                                 },
                                 onSelectScreenshot = { screenshot ->
-                                    onAction(SelectScreenshot(screenshot))
+                                    onAction(ScreenshotAction.SelectScreenshot(screenshot))
                                 },
                                 onNextScreenshot = {
                                     onAction(ScreenshotAction.NextScreenshot)
@@ -188,13 +187,13 @@ fun WindowScope.App(mainStateHolder: MainStateHolder) {
                                     onAction(ScreenshotAction.PreviousScreenshot)
                                 },
                                 onUpdateSearchText = {
-                                    onAction(UpdateSearchText(it))
+                                    onAction(ScreenshotAction.UpdateSearchText(it))
                                 },
                                 onSelectCommand = {
-                                    onAction(SelectScreenshotCommand(it))
+                                    onAction(ScreenshotAction.SelectScreenshotCommand(it))
                                 },
                                 onUpdateSortType = {
-                                    onAction(UpdateSortType(it))
+                                    onAction(ScreenshotAction.UpdateSortType(it))
                                 },
                             )
                         }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainCategory.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainCategory.kt
@@ -4,4 +4,5 @@ enum class MainCategory {
     Command,
     Text,
     Screenshot,
+    File,
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/dropbox/SearchSortDropBox.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/dropbox/SearchSortDropBox.kt
@@ -14,8 +14,6 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
@@ -27,6 +25,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Check
+import com.composables.icons.lucide.ChevronDown
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Search
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
@@ -51,25 +53,27 @@ fun SearchSortDropBox(
                     }.width(40.dp),
         ) {
             Icon(
-                imageVector = Icons.Default.Search,
+                imageVector = Lucide.Search,
                 contentDescription = null,
                 modifier =
                     Modifier
                         .align(Alignment.Center)
                         .offset(x = (-6).dp)
                         .padding(vertical = 8.dp)
-                        .size(24.dp),
+                        .size(24.dp)
+                        .padding(2.dp),
             )
 
             Icon(
-                imageVector = Icons.Filled.ArrowDropDown,
+                imageVector = Lucide.ChevronDown,
                 contentDescription = "Device DropDown Icon",
                 tint = MaterialTheme.colors.onBackground,
                 modifier =
                     Modifier
                         .align(Alignment.Center)
-                        .offset(x = 10.dp)
-                        .size(24.dp),
+                        .offset(x = 12.dp)
+                        .size(24.dp)
+                        .padding(4.dp),
             )
         }
     }
@@ -96,7 +100,7 @@ fun SearchSortDropBox(
                     ) {
                         if (selectedSortType == sortType) {
                             Icon(
-                                imageVector = Icons.Default.Check,
+                                imageVector = Lucide.Check,
                                 contentDescription = "Check",
                                 tint = MaterialTheme.colors.onBackground,
                                 modifier = Modifier.align(Alignment.Center).size(20.dp),

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRail.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRail.kt
@@ -5,14 +5,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DoubleArrow
-import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Textsms
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Camera
+import com.composables.icons.lucide.ChevronsRight
+import com.composables.icons.lucide.Command
+import com.composables.icons.lucide.File
+import com.composables.icons.lucide.FileText
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Settings
+import com.composables.icons.lucide.Text
 import jp.kaleidot725.adbpad.MainCategory
 
 @Composable
@@ -24,7 +28,7 @@ fun NavigationRail(
     Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         NavigationRailItem(
             label = "Command",
-            icon = Icons.Default.DoubleArrow,
+            icon = Lucide.ChevronsRight,
             contentDescription = "device menu",
             isSelected = category == MainCategory.Command,
             onClick = { onSelectCategory(MainCategory.Command) },
@@ -32,7 +36,7 @@ fun NavigationRail(
 
         NavigationRailItem(
             label = "Text",
-            icon = Icons.Default.Textsms,
+            icon = Lucide.FileText,
             contentDescription = "text menu",
             isSelected = category == MainCategory.Text,
             onClick = { onSelectCategory(MainCategory.Text) },
@@ -40,17 +44,27 @@ fun NavigationRail(
 
         NavigationRailItem(
             label = "Screenshot",
-            icon = Icons.Default.PhotoCamera,
+            icon = Lucide.Camera,
             contentDescription = "screenshot menu",
             isSelected = category == MainCategory.Screenshot,
             onClick = { onSelectCategory(MainCategory.Screenshot) },
         )
 
+        if (false) {
+            NavigationRailItem(
+                label = "File",
+                icon = Lucide.File,
+                contentDescription = "file menu",
+                isSelected = category == MainCategory.File,
+                onClick = { onSelectCategory(MainCategory.File) },
+            )
+        }
+
         Spacer(Modifier.weight(1.0f))
 
         NavigationRailItem(
             label = "Setting",
-            icon = Icons.Default.Settings,
+            icon = Lucide.Settings,
             contentDescription = "device menu",
             isSelected = false,
             onClick = onOpenSetting,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRailItem.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRailItem.kt
@@ -1,30 +1,34 @@
 package jp.kaleidot725.adbpad.ui.component.rail
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
 import androidx.compose.material.Icon
-import androidx.compose.material.icons.Icons
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Power
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
-import jp.kaleidot725.adbpad.ui.component.text.AutoSizableText
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun NavigationRailItem(
     label: String = "",
@@ -36,31 +40,40 @@ fun NavigationRailItem(
     Box(
         modifier =
             Modifier
-                .height(50.dp)
-                .width(75.dp)
+                .size(40.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .clickableBackground(isSelected)
-                .clickable(onClick = onClick)
-                .padding(4.dp),
+                .clickable(onClick = onClick),
     ) {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-            modifier = Modifier.align(Alignment.Center),
+        TooltipArea(
+            delayMillis = 300,
+            tooltip = {
+                Card(
+                    modifier =
+                        Modifier.border(1.dp, UserColor.getSplitterColor()),
+                ) {
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.caption,
+                        modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
+                    )
+                }
+            },
+            tooltipPlacement =
+                TooltipPlacement.ComponentRect(
+                    anchor = Alignment.CenterEnd,
+                    alignment = Alignment.CenterEnd,
+                    offset = DpOffset(12.dp, 0.dp),
+                ),
+            modifier =
+                Modifier
+                    .wrapContentSize()
+                    .align(Alignment.Center),
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = contentDescription,
-                modifier = Modifier.size(20.dp).align(Alignment.CenterHorizontally),
             )
-
-            if (label.isNotEmpty()) {
-                AutoSizableText(
-                    text = label,
-                    style = TextStyle(textAlign = TextAlign.Center),
-                    maxFontSize = 12.sp,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                )
-            }
         }
     }
 }
@@ -70,7 +83,7 @@ fun NavigationRailItem(
 private fun NavigationRailItemPreview() {
     NavigationRailItem(
         label = "Power",
-        icon = Icons.Default.Power,
+        icon = Lucide.Power,
         contentDescription = null,
         isSelected = false,
         onClick = {},

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
@@ -3,13 +3,16 @@ package jp.kaleidot725.adbpad.ui.screen
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommand
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandGroup
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.screen.command.component.CommandList
 import jp.kaleidot725.adbpad.ui.screen.command.component.CommandTab
 
@@ -25,8 +28,11 @@ fun CommandScreen(
         CommandTab(
             filtered = filtered,
             onClick = onClickFilter,
-            modifier = Modifier.padding(8.dp),
+            modifier = Modifier.height(48.dp).padding(8.dp),
         )
+
+        Divider(color = UserColor.getSplitterColor())
+
         CommandList(
             commands =
                 when (filtered) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTabItem.kt
@@ -6,20 +6,22 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Preview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Presentation
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
 
 @Composable
@@ -33,21 +35,29 @@ fun CommandTabItem(
     Box(
         modifier
             .widthIn(min = 200.dp)
-            .heightIn(min = 40.dp)
+            .heightIn(min = 32.dp)
             .clickableBackground(isSelected = isSelected, shape = RoundedCornerShape(8.dp))
             .clip(RoundedCornerShape(8.dp))
             .clickable(onClick = onClick),
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            modifier = Modifier.align(Alignment.CenterStart).padding(start = 12.dp, top = 4.dp),
-        )
+        Box(
+            modifier =
+                Modifier
+                    .padding(start = 12.dp)
+                    .align(Alignment.CenterStart),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
         Text(
             text = title,
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.subtitle1,
-            modifier = Modifier.align(Alignment.Center),
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.align(Alignment.Center).padding(bottom = 4.dp),
         )
     }
 }
@@ -56,7 +66,7 @@ fun CommandTabItem(
 @Composable
 private fun CommandTabItemPreview() {
     Row {
-        CommandTabItem("one", Icons.Default.Preview, false, {})
-        CommandTabItem("two", Icons.Default.Preview, true, {})
+        CommandTabItem("one", Lucide.Presentation, false, {})
+        CommandTabItem("two", Lucide.Presentation, true, {})
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
@@ -12,15 +12,15 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FileCopy
-import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ClipboardCopy
+import com.composables.icons.lucide.FolderOpen
+import com.composables.icons.lucide.Lucide
 
 @Composable
 fun ScreenshotActions(
@@ -44,7 +44,7 @@ fun ScreenshotActions(
                     .align(Alignment.CenterVertically),
         ) {
             Icon(
-                imageVector = Icons.Default.FileCopy,
+                imageVector = Lucide.ClipboardCopy,
                 contentDescription = "copy",
                 modifier = Modifier.height(20.dp),
             )
@@ -61,7 +61,7 @@ fun ScreenshotActions(
                     .align(Alignment.CenterVertically),
         ) {
             Icon(
-                imageVector = Icons.Default.FileOpen,
+                imageVector = Lucide.FolderOpen,
                 contentDescription = "copy",
                 modifier = Modifier.height(20.dp),
             )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotButton.kt
@@ -15,14 +15,14 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ChevronDown
+import com.composables.icons.lucide.Lucide
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
 
@@ -80,7 +80,7 @@ fun ScreenshotButton(
                         .clickable(enabled = canCapture) { onChangeType() },
             ) {
                 Icon(
-                    imageVector = Icons.Default.ArrowDropDown,
+                    imageVector = Lucide.ChevronDown,
                     contentDescription = "",
                     tint = MaterialTheme.colors.onPrimary,
                     modifier = Modifier.align(Alignment.Center),

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.DropdownMenu
@@ -11,7 +12,6 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,6 +21,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Check
+import com.composables.icons.lucide.Lucide
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 
 @Composable
@@ -57,10 +59,16 @@ fun ScreenshotDropDownButton(
                     },
                 ) {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Box(modifier = Modifier.size(20.dp).align(Alignment.CenterVertically)) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .padding(top = 8.dp)
+                                    .size(20.dp)
+                                    .align(Alignment.CenterVertically),
+                        ) {
                             if (command == selectedCommand) {
                                 Icon(
-                                    imageVector = Icons.Default.Check,
+                                    imageVector = Lucide.Check,
                                     contentDescription = "",
                                     modifier = Modifier.fillMaxSize(),
                                 )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotHeader.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotHeader.kt
@@ -10,13 +10,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Trash
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.component.dropbox.SearchSortDropBox
@@ -54,7 +54,7 @@ fun ScreenshotHeader(
                     .align(Alignment.CenterVertically),
         ) {
             Icon(
-                imageVector = Icons.Default.Delete,
+                imageVector = Lucide.Trash,
                 contentDescription = "delete",
                 modifier = Modifier.height(20.dp),
             )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/LanguageDropButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/LanguageDropButton.kt
@@ -12,8 +12,6 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,6 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ChevronDown
+import com.composables.icons.lucide.Lucide
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
 import jp.kaleidot725.adbpad.ui.common.resource.defaultBorder
@@ -52,7 +52,7 @@ fun LanguageDropButton(
             )
 
             Icon(
-                imageVector = Icons.Default.ArrowDropDown,
+                imageVector = Lucide.ChevronDown,
                 contentDescription = null,
                 modifier = Modifier.align(Alignment.CenterVertically),
             )
@@ -81,14 +81,13 @@ fun LanguageDropButton(
     }
 }
 
-private fun Language.Type.title(): String {
-    return when (this) {
+private fun Language.Type.title(): String =
+    when (this) {
         Language.Type.ENGLISH -> Language.settingLanguageEnglish
         Language.Type.JAPANESE -> Language.settingLanguageJapanese
         Language.Type.CHINESE -> Language.settingLanguageChinese
         Language.Type.TURKISH -> Language.settingLanguageTurkish
     }
-}
 
 @Preview
 @Composable

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandActions.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandActions.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.DropdownMenu
@@ -13,7 +14,6 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,6 +23,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Check
+import com.composables.icons.lucide.Lucide
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.dummy.TextCommandDummy
@@ -68,10 +70,12 @@ fun TextCommandActions(
                         },
                     ) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Box(modifier = Modifier.size(20.dp).align(Alignment.CenterVertically)) {
+                            Box(
+                                modifier = Modifier.padding(top = 8.dp).size(20.dp).align(Alignment.CenterVertically),
+                            ) {
                                 if (selectedOption == option) {
                                     Icon(
-                                        imageVector = Icons.Default.Check,
+                                        imageVector = Lucide.Check,
                                         contentDescription = "",
                                         modifier = Modifier.fillMaxSize(),
                                     )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandButton.kt
@@ -15,14 +15,14 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ChevronDown
+import com.composables.icons.lucide.Lucide
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
@@ -85,7 +85,7 @@ fun TextCommandButton(
                         .clickable(enabled = canSend) { onChangeOption() },
             ) {
                 Icon(
-                    imageVector = Icons.Default.ArrowDropDown,
+                    imageVector = Lucide.ChevronDown,
                     contentDescription = "",
                     tint = MaterialTheme.colors.onPrimary,
                     modifier = Modifier.align(Alignment.Center),

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandHeader.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandHeader.kt
@@ -10,14 +10,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Create
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Pencil
+import com.composables.icons.lucide.Trash
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.ui.component.dropbox.SearchSortDropBox
@@ -56,7 +56,7 @@ fun TextCommandHeader(
                     .align(Alignment.CenterVertically),
         ) {
             Icon(
-                imageVector = Icons.Default.Create,
+                imageVector = Lucide.Pencil,
                 contentDescription = "create",
                 modifier = Modifier.height(20.dp),
             )
@@ -72,7 +72,7 @@ fun TextCommandHeader(
                     .align(Alignment.CenterVertically),
         ) {
             Icon(
-                imageVector = Icons.Default.Delete,
+                imageVector = Lucide.Trash,
                 contentDescription = "delete",
                 modifier = Modifier.height(20.dp),
             )

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DropDownDeviceMenu.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DropDownDeviceMenu.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,6 +27,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Settings
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.device.DeviceState
 import jp.kaleidot725.adbpad.domain.model.language.Language
@@ -73,7 +74,7 @@ fun DropDownDeviceMenu(
                 Spacer(modifier = Modifier.weight(1.0f))
 
                 CommandIconButton(
-                    image = Icons.Default.Settings,
+                    image = Lucide.Settings,
                     onClick = {
                         expanded = false
                         onOpenDevice()


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and functionality of the UI components in the `adbpad` project. The most important changes are the addition of a new `MainCategory`, the use of wildcard imports for `CommandAction` and `ScreenshotAction`, the replacement of `Icons` with `Lucide` icons, and the enhancement of the `NavigationRailItem` component with tooltips.

### New Features:
* Added a new `MainCategory` called `File` and included it in the `NavigationRail` component, though it is currently conditionally rendered. [[1]](diffhunk://#diff-cbfcde9c929bac3097ecfd6d952c8ffa2b35756c498c453545b5dd5ae9f56616R7) [[2]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095L27-R67)

### Import Improvements:
* Updated imports to use wildcard imports for `CommandAction` and `ScreenshotAction` to simplify the code.

### Icon Updates:
* Replaced `Icons` with `Lucide` icons across various components to standardize the icon set used in the application. [[1]](diffhunk://#diff-49295578804bc897e943f76f27887b102cd55c83d2a82fec41517e8e60c33cdaL17-L18) [[2]](diffhunk://#diff-49295578804bc897e943f76f27887b102cd55c83d2a82fec41517e8e60c33cdaR28-R31) [[3]](diffhunk://#diff-49295578804bc897e943f76f27887b102cd55c83d2a82fec41517e8e60c33cdaL54-R76) [[4]](diffhunk://#diff-49295578804bc897e943f76f27887b102cd55c83d2a82fec41517e8e60c33cdaL99-R103) [[5]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095L8-R19) [[6]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095L27-R67) [[7]](diffhunk://#diff-375a0c70cb0bf6b46d62fd403b7e324e31bdde2eac7f77ee58ec773246b87b0dL73-R86) [[8]](diffhunk://#diff-919693bd37d4ba49e6f588dd1e1820833ab2a3e679f649000ff48d87ed56930dR9-R24) [[9]](diffhunk://#diff-919693bd37d4ba49e6f588dd1e1820833ab2a3e679f649000ff48d87ed56930dL59-R70)

### UI Enhancements:
* Enhanced the `NavigationRailItem` component by adding tooltips for better user experience and modifying its layout properties. [[1]](diffhunk://#diff-375a0c70cb0bf6b46d62fd403b7e324e31bdde2eac7f77ee58ec773246b87b0dR4-R31) [[2]](diffhunk://#diff-375a0c70cb0bf6b46d62fd403b7e324e31bdde2eac7f77ee58ec773246b87b0dL39-L63)

### Miscellaneous Changes:
* Added a `Divider` in the `CommandScreen` for improved visual separation.

## Screenshot

![image](https://github.com/user-attachments/assets/9100613c-58c9-4669-ad93-642421294e0e)