### PR TITLE
feat: fix refresh button layout

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -73,13 +73,25 @@ private fun TopSection(
         modifier = Modifier.fillMaxWidth().height(40.dp),
     ) {
         Box {
-            Row(Modifier.align(Alignment.CenterStart).wrapContentSize().padding(start = 4.dp)) {
+            Row(Modifier.align(Alignment.CenterStart).wrapContentSize().padding(start = 12.dp)) {
                 DropDownDeviceMenu(
                     devices = state.devices,
                     selectedDevice = state.selectedDevice,
                     onSelectDevice = onSelectDevice,
                     onOpenDevice = onOpenDevice,
                     modifier = Modifier.wrapContentWidth(),
+                )
+
+                CommandIconButton(
+                    modifier =
+                        Modifier
+                            .padding(vertical = 4.dp)
+                            .onPointerEvent(PointerEventType.Press) { isPress = true }
+                            .onPointerEvent(PointerEventType.Release) { isPress = false },
+                    image = Lucide.RefreshCcw,
+                    degrees = degrees,
+                    onClick = { onRefresh() },
+                    padding = 2.dp,
                 )
             }
 
@@ -126,19 +138,6 @@ private fun TopSection(
                 CommandIconButton(
                     image = Lucide.Square,
                     onClick = { onExecuteCommand(DeviceControlCommand.Recents) },
-                    padding = 2.dp,
-                )
-
-                CommandIconDivider()
-
-                CommandIconButton(
-                    modifier =
-                        Modifier
-                            .onPointerEvent(PointerEventType.Press) { isPress = true }
-                            .onPointerEvent(PointerEventType.Release) { isPress = false },
-                    image = Lucide.RefreshCcw,
-                    degrees = degrees,
-                    onClick = { onRefresh() },
                     padding = 2.dp,
                 )
             }


### PR DESCRIPTION
This pull request includes changes to the `TopSection` function in the `src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt` file. The changes involve modifying the layout and behavior of UI components for better user interaction.

### UI Layout and Behavior Improvements:

* Adjusted the padding of the `Row` containing the `DropDownDeviceMenu` to improve spacing.
* Added a new `CommandIconButton` for refreshing the device list, including pointer event handling to provide visual feedback on press and release.
* Removed redundant `CommandIconDivider` and relocated the `CommandIconButton` for better organization and clarity in the UI layout.

<img width="1801" alt="image" src="https://github.com/user-attachments/assets/b2daf3f7-0dd1-49af-9340-89da41fc33f4" />