### PR TITLE
feat: add tool tip

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -217,6 +217,24 @@ object Language : StringResources {
     override val sortByNameDesc: String
         get() = getCurrentResources().sortByNameDesc
 
+    // TopSection tooltips
+    override val tooltipRefresh: String
+        get() = getCurrentResources().tooltipRefresh
+    override val tooltipPower: String
+        get() = getCurrentResources().tooltipPower
+    override val tooltipVolumeUp: String
+        get() = getCurrentResources().tooltipVolumeUp
+    override val tooltipVolumeDown: String
+        get() = getCurrentResources().tooltipVolumeDown
+    override val tooltipVolumeMute: String
+        get() = getCurrentResources().tooltipVolumeMute
+    override val tooltipBack: String
+        get() = getCurrentResources().tooltipBack
+    override val tooltipHome: String
+        get() = getCurrentResources().tooltipHome
+    override val tooltipRecents: String
+        get() = getCurrentResources().tooltipRecents
+
     private var currentType: Type = Type.ENGLISH
 
     fun switch(type: Type) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -235,6 +235,18 @@ object Language : StringResources {
     override val tooltipRecents: String
         get() = getCurrentResources().tooltipRecents
 
+    // NavigationRail tooltips
+    override val tooltipCommand: String
+        get() = getCurrentResources().tooltipCommand
+    override val tooltipText: String
+        get() = getCurrentResources().tooltipText
+    override val tooltipScreenshot: String
+        get() = getCurrentResources().tooltipScreenshot
+    override val tooltipFile: String
+        get() = getCurrentResources().tooltipFile
+    override val tooltipSetting: String
+        get() = getCurrentResources().tooltipSetting
+
     private var currentType: Type = Type.ENGLISH
 
     fun switch(type: Type) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -126,4 +126,11 @@ object ChineseResources : StringResources {
     override val tooltipBack: String = "返回"
     override val tooltipHome: String = "主页"
     override val tooltipRecents: String = "最近任务"
+
+    // NavigationRail tooltips
+    override val tooltipCommand: String = "命令"
+    override val tooltipText: String = "文本"
+    override val tooltipScreenshot: String = "截图"
+    override val tooltipFile: String = "文件"
+    override val tooltipSetting: String = "设置"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -116,4 +116,14 @@ object ChineseResources : StringResources {
 
     override val sortByNameAsc: String = "名稱(升序)"
     override val sortByNameDesc: String = "名稱(降序)"
+
+    // TopSection tooltips
+    override val tooltipRefresh: String = "刷新"
+    override val tooltipPower: String = "电源"
+    override val tooltipVolumeUp: String = "音量增大"
+    override val tooltipVolumeDown: String = "音量减小"
+    override val tooltipVolumeMute: String = "静音"
+    override val tooltipBack: String = "返回"
+    override val tooltipHome: String = "主页"
+    override val tooltipRecents: String = "最近任务"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -126,4 +126,11 @@ object EnglishResources : StringResources {
     override val tooltipBack: String = "Back"
     override val tooltipHome: String = "Home"
     override val tooltipRecents: String = "Recents"
+
+    // NavigationRail tooltips
+    override val tooltipCommand: String = "Command"
+    override val tooltipText: String = "Text"
+    override val tooltipScreenshot: String = "Screenshot"
+    override val tooltipFile: String = "File"
+    override val tooltipSetting: String = "Setting"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -116,4 +116,14 @@ object EnglishResources : StringResources {
 
     override val sortByNameAsc: String = "Name(Asc)"
     override val sortByNameDesc: String = "Name(Desc)"
+
+    // TopSection tooltips
+    override val tooltipRefresh: String = "Refresh"
+    override val tooltipPower: String = "Power"
+    override val tooltipVolumeUp: String = "Volume Up"
+    override val tooltipVolumeDown: String = "Volume Down"
+    override val tooltipVolumeMute: String = "Volume Mute"
+    override val tooltipBack: String = "Back"
+    override val tooltipHome: String = "Home"
+    override val tooltipRecents: String = "Recents"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -125,4 +125,11 @@ object JapaneseResources : StringResources {
     override val tooltipBack: String = "戻る"
     override val tooltipHome: String = "ホーム"
     override val tooltipRecents: String = "最近のアプリ"
+
+    // NavigationRail tooltips
+    override val tooltipCommand: String = "コマンド"
+    override val tooltipText: String = "テキスト"
+    override val tooltipScreenshot: String = "スクリーンショット"
+    override val tooltipFile: String = "ファイル"
+    override val tooltipSetting: String = "設定"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -115,4 +115,14 @@ object JapaneseResources : StringResources {
 
     override val sortByNameAsc: String = "名前(昇順)"
     override val sortByNameDesc: String = "名前(降順)"
+
+    // TopSection tooltips
+    override val tooltipRefresh: String = "更新"
+    override val tooltipPower: String = "電源"
+    override val tooltipVolumeUp: String = "音量アップ"
+    override val tooltipVolumeDown: String = "音量ダウン"
+    override val tooltipVolumeMute: String = "ミュート"
+    override val tooltipBack: String = "戻る"
+    override val tooltipHome: String = "ホーム"
+    override val tooltipRecents: String = "最近のアプリ"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -114,4 +114,14 @@ interface StringResources {
 
     val sortByNameAsc: String
     val sortByNameDesc: String
+
+    // TopSection tooltips
+    val tooltipRefresh: String
+    val tooltipPower: String
+    val tooltipVolumeUp: String
+    val tooltipVolumeDown: String
+    val tooltipVolumeMute: String
+    val tooltipBack: String
+    val tooltipHome: String
+    val tooltipRecents: String
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -124,4 +124,11 @@ interface StringResources {
     val tooltipBack: String
     val tooltipHome: String
     val tooltipRecents: String
+
+    // NavigationRail tooltips
+    val tooltipCommand: String
+    val tooltipText: String
+    val tooltipScreenshot: String
+    val tooltipFile: String
+    val tooltipSetting: String
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -126,4 +126,11 @@ object TurkishResources : StringResources {
     override val tooltipBack: String = "Geri"
     override val tooltipHome: String = "Ana Ekran"
     override val tooltipRecents: String = "Son Uygulamalar"
+
+    // NavigationRail tooltips
+    override val tooltipCommand: String = "Komut"
+    override val tooltipText: String = "Metin"
+    override val tooltipScreenshot: String = "Ekran Görüntüsü"
+    override val tooltipFile: String = "Dosya"
+    override val tooltipSetting: String = "Ayarlar"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -116,4 +116,14 @@ object TurkishResources : StringResources {
 
     override val sortByNameAsc: String = "İsim (artan sıra)"
     override val sortByNameDesc: String = " İsim (azalan sıra)"
+
+    // TopSection tooltips
+    override val tooltipRefresh: String = "Yenile"
+    override val tooltipPower: String = "Güç"
+    override val tooltipVolumeUp: String = "Sesi Artır"
+    override val tooltipVolumeDown: String = "Sesi Azalt"
+    override val tooltipVolumeMute: String = "Sessiz"
+    override val tooltipBack: String = "Geri"
+    override val tooltipHome: String = "Ana Ekran"
+    override val tooltipRecents: String = "Son Uygulamalar"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRail.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRail.kt
@@ -18,6 +18,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Text
 import jp.kaleidot725.adbpad.MainCategory
+import jp.kaleidot725.adbpad.domain.model.language.Language
 
 @Composable
 fun NavigationRail(
@@ -27,7 +28,7 @@ fun NavigationRail(
 ) {
     Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         NavigationRailItem(
-            label = "Command",
+            label = Language.tooltipCommand,
             icon = Lucide.ChevronsRight,
             contentDescription = "device menu",
             isSelected = category == MainCategory.Command,
@@ -35,7 +36,7 @@ fun NavigationRail(
         )
 
         NavigationRailItem(
-            label = "Text",
+            label = Language.tooltipText,
             icon = Lucide.FileText,
             contentDescription = "text menu",
             isSelected = category == MainCategory.Text,
@@ -43,7 +44,7 @@ fun NavigationRail(
         )
 
         NavigationRailItem(
-            label = "Screenshot",
+            label = Language.tooltipScreenshot,
             icon = Lucide.Camera,
             contentDescription = "screenshot menu",
             isSelected = category == MainCategory.Screenshot,
@@ -52,7 +53,7 @@ fun NavigationRail(
 
         if (false) {
             NavigationRailItem(
-                label = "File",
+                label = Language.tooltipFile,
                 icon = Lucide.File,
                 contentDescription = "file menu",
                 isSelected = category == MainCategory.File,
@@ -63,7 +64,7 @@ fun NavigationRail(
         Spacer(Modifier.weight(1.0f))
 
         NavigationRailItem(
-            label = "Setting",
+            label = Language.tooltipSetting,
             icon = Lucide.Settings,
             contentDescription = "device menu",
             isSelected = false,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -2,6 +2,10 @@ package jp.kaleidot725.adbpad.ui.section.top
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -10,8 +14,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,7 +28,9 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import com.composables.icons.lucide.Circle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Power
@@ -34,6 +42,7 @@ import com.composables.icons.lucide.Volume2
 import com.composables.icons.lucide.VolumeX
 import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
+import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.component.button.CommandIconButton
 import jp.kaleidot725.adbpad.ui.component.divider.CommandIconDivider
 import jp.kaleidot725.adbpad.ui.section.top.component.DropDownDeviceMenu
@@ -56,7 +65,7 @@ fun TopSection(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 @Composable
 private fun TopSection(
     state: TopState,
@@ -82,67 +91,130 @@ private fun TopSection(
                     modifier = Modifier.wrapContentWidth(),
                 )
 
-                CommandIconButton(
-                    modifier =
-                        Modifier
-                            .padding(vertical = 4.dp)
-                            .onPointerEvent(PointerEventType.Press) { isPress = true }
-                            .onPointerEvent(PointerEventType.Release) { isPress = false },
-                    image = Lucide.RefreshCcw,
-                    degrees = degrees,
-                    onClick = { onRefresh() },
-                    padding = 2.dp,
-                )
+                CommandTooltip(
+                    text = Language.tooltipRefresh,
+                ) {
+                    CommandIconButton(
+                        modifier =
+                            Modifier
+                                .padding(vertical = 4.dp)
+                                .onPointerEvent(PointerEventType.Press) { isPress = true }
+                                .onPointerEvent(PointerEventType.Release) { isPress = false },
+                        image = Lucide.RefreshCcw,
+                        degrees = degrees,
+                        onClick = { onRefresh() },
+                        padding = 2.dp,
+                    )
+                }
             }
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier.align(Alignment.CenterEnd).wrapContentSize().padding(4.dp),
             ) {
-                CommandIconButton(
-                    image = Lucide.Power,
-                    onClick = { onExecuteCommand(DeviceControlCommand.Power) },
-                    padding = 2.dp,
-                )
+                CommandTooltip(
+                    text = Language.tooltipPower,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.Power,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Power) },
+                        padding = 2.dp,
+                    )
+                }
 
-                CommandIconButton(
-                    image = Lucide.Volume2,
-                    onClick = { onExecuteCommand(DeviceControlCommand.VolumeUp) },
-                )
+                CommandTooltip(
+                    text = Language.tooltipVolumeUp,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.Volume2,
+                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeUp) },
+                    )
+                }
 
-                CommandIconButton(
-                    image = Lucide.Volume1,
-                    onClick = { onExecuteCommand(DeviceControlCommand.VolumeDown) },
-                )
+                CommandTooltip(
+                    text = Language.tooltipVolumeDown,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.Volume1,
+                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeDown) },
+                    )
+                }
 
-                CommandIconButton(
-                    image = Lucide.VolumeX,
-                    onClick = { onExecuteCommand(DeviceControlCommand.VolumeMute) },
-                )
+                CommandTooltip(
+                    text = Language.tooltipVolumeMute,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.VolumeX,
+                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeMute) },
+                    )
+                }
 
                 CommandIconDivider()
 
-                CommandIconButton(
-                    image = Lucide.Triangle,
-                    degrees = -90f,
-                    onClick = { onExecuteCommand(DeviceControlCommand.Back) },
-                    padding = 2.dp,
-                )
+                CommandTooltip(
+                    text = Language.tooltipBack,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.Triangle,
+                        degrees = -90f,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Back) },
+                        padding = 2.dp,
+                    )
+                }
 
-                CommandIconButton(
-                    image = Lucide.Circle,
-                    onClick = { onExecuteCommand(DeviceControlCommand.Home) },
-                    padding = 2.dp,
-                )
+                CommandTooltip(
+                    text = Language.tooltipHome,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.Circle,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Home) },
+                        padding = 2.dp,
+                    )
+                }
 
-                CommandIconButton(
-                    image = Lucide.Square,
-                    onClick = { onExecuteCommand(DeviceControlCommand.Recents) },
-                    padding = 2.dp,
-                )
+                CommandTooltip(
+                    text = Language.tooltipRecents,
+                ) {
+                    CommandIconButton(
+                        image = Lucide.Square,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Recents) },
+                        padding = 2.dp,
+                    )
+                }
             }
         }
     }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CommandTooltip(
+    text: String,
+    tooltipPlacement: TooltipPlacement = TooltipPlacement.ComponentRect(
+        anchor = Alignment.TopCenter,
+        alignment = Alignment.BottomCenter,
+        offset = DpOffset(0.dp, 30.dp),
+    ),
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    TooltipArea(
+        delayMillis = 300,
+        tooltip = {
+            Card(
+                modifier = Modifier.border(1.dp, UserColor.getSplitterColor()),
+            ) {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.caption,
+                    modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
+                )
+            }
+        },
+        tooltipPlacement = tooltipPlacement,
+        modifier = modifier,
+        content = content
+    )
 }
 
 @Preview

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import com.composables.icons.lucide.Circle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Power
@@ -43,6 +42,7 @@ import com.composables.icons.lucide.VolumeX
 import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.button.CommandIconButton
 import jp.kaleidot725.adbpad.ui.component.divider.CommandIconDivider
 import jp.kaleidot725.adbpad.ui.section.top.component.DropDownDeviceMenu
@@ -190,13 +190,14 @@ private fun TopSection(
 @Composable
 private fun CommandTooltip(
     text: String,
-    tooltipPlacement: TooltipPlacement = TooltipPlacement.ComponentRect(
-        anchor = Alignment.TopCenter,
-        alignment = Alignment.BottomCenter,
-        offset = DpOffset(0.dp, 30.dp),
-    ),
+    tooltipPlacement: TooltipPlacement =
+        TooltipPlacement.ComponentRect(
+            anchor = Alignment.TopCenter,
+            alignment = Alignment.BottomCenter,
+            offset = DpOffset(0.dp, 30.dp),
+        ),
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     TooltipArea(
         delayMillis = 300,
@@ -213,7 +214,7 @@ private fun CommandTooltip(
         },
         tooltipPlacement = tooltipPlacement,
         modifier = modifier,
-        content = content
+        content = content,
     )
 }
 


### PR DESCRIPTION
This pull request introduces tooltips for various UI components in multiple languages and integrates them into the `NavigationRail` and `TopSection` components. It also adds a reusable `CommandTooltip` composable for displaying tooltips. The main changes are categorized below:

### Tooltip Support in Language Resources:
* Added tooltip strings for both `TopSection` (e.g., `tooltipRefresh`, `tooltipPower`) and `NavigationRail` (e.g., `tooltipCommand`, `tooltipSetting`) to the `StringResources` interface and implemented them in `EnglishResources`, `ChineseResources`, `JapaneseResources`, and `TurkishResources`. (`[[1]](diffhunk://#diff-5d08f0063fba320b02cb14c9fb64d24b7ea65c11ff9a77f47cb8efcc627a8c6aR220-R249)`, `[[2]](diffhunk://#diff-594031841b8fb02bbafe5d12494fb8440c913435b2df7a53e2b3da6c72e4369eR119-R135)`, `[[3]](diffhunk://#diff-ed0f482c0e642d8cb3cb91655707c86d2bfedd893b4d0a6c2c21f35122c6437fR119-R135)`, `[[4]](diffhunk://#diff-2477d85a4cf96726bf08ddb8fd0be90e659bbad751dffc081d24cdd549b6c7f3R118-R134)`, `[[5]](diffhunk://#diff-b35228af6b444eabcaa2b8f89dd8fd4c85531ac2a27b8b37ab0ba12f623d7051R119-R135)`, `[[6]](diffhunk://#diff-c176a2a6de40c297218931afa52676182df0f30d505dec87a61767159bfe0ecbR117-R133)`)

### Integration of Tooltips in `NavigationRail`:
* Replaced hardcoded labels in `NavigationRail` items with localized tooltip values from the `Language` object (e.g., `Language.tooltipCommand`, `Language.tooltipText`). (`[[1]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095L30-R47)`, `[[2]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095L55-R56)`, `[[3]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095L66-R67)`)

### Integration of Tooltips in `TopSection`:
* Added tooltips for buttons in `TopSection` (e.g., Refresh, Power, Volume, Back, Home, Recents) using the new `CommandTooltip` composable. (`[[1]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR94-R96)`, `[[2]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR109-R177)`, `[[3]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR187-R218)`)

### New `CommandTooltip` Composable:
* Created a reusable `CommandTooltip` composable for displaying tooltips with customizable placement and styling. (`[src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.ktR187-R218](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR187-R218)`)

### Miscellaneous Updates:
* Added necessary imports for tooltips and related components in `TopSection` and `NavigationRail`. (`[[1]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR5-R8)`, `[[2]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR17-R20)`, `[[3]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR31-R33)`, `[[4]](diffhunk://#diff-2a07bd61a4e5c7b6ffcba7baee75d8759a9b7f45a7d0c730d729d5ef86cfdffeR45)`, `[[5]](diffhunk://#diff-c28b591f2f70aff5a79acbfcebb9df31eb3a5ada370913a7a45d721ae54c2095R21)`)


https://github.com/user-attachments/assets/7fcc8c5d-9d2f-4c21-b51a-da4dab33cadc