### PR TITLE
feat: add floating window option

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.MenuBar
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
 import jp.kaleidot725.adbpad.core.di.domainModule
@@ -102,6 +104,39 @@ fun main() {
                 onCloseRequest = ::exitApplication,
                 state = windowState,
             ) {
+                MenuBar {
+                    Menu(Language.menuWindow) {
+                        CheckboxItem(
+                            text = Language.menuWindowMaximize,
+                            checked = windowState.placement == WindowPlacement.Maximized,
+                            onCheckedChange = {
+                                windowState.placement = if (windowState.placement == WindowPlacement.Maximized) {
+                                    WindowPlacement.Floating
+                                } else {
+                                    WindowPlacement.Maximized
+                                }
+                            }
+                        )
+                        CheckboxItem(
+                            text = Language.menuWindowMinimize,
+                            checked = windowState.isMinimized,
+                            onCheckedChange = {
+                                windowState.isMinimized = !windowState.isMinimized
+                            }
+                        )
+                        CheckboxItem(
+                            text = Language.menuWindowFullscreen,
+                            checked = windowState.placement == WindowPlacement.Fullscreen,
+                            onCheckedChange = {
+                                windowState.placement = if (windowState.placement == WindowPlacement.Fullscreen) {
+                                    WindowPlacement.Floating
+                                } else {
+                                    WindowPlacement.Fullscreen
+                                }
+                            }
+                        )
+                    }
+                }
                 DisposableEffect(Unit) { onDispose { onAction(MainAction.SaveSetting(this@Window.getWindowSize())) } }
                 MaterialTheme(colors = if (state.isDark) DarkColors else LightColors) {
                     DevelopmentEntryPoint {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -103,6 +103,7 @@ fun main() {
                 icon = painterResource("icon.png"),
                 onCloseRequest = ::exitApplication,
                 state = windowState,
+                alwaysOnTop = state.isAlwaysOnTop,
             ) {
                 MenuBar {
                     Menu(Language.menuWindow) {
@@ -133,6 +134,13 @@ fun main() {
                                 } else {
                                     WindowPlacement.Fullscreen
                                 }
+                            }
+                        )
+                        CheckboxItem(
+                            text = Language.menuWindowAlwaysOnTop,
+                            checked = state.isAlwaysOnTop,
+                            onCheckedChange = {
+                                onAction(MainAction.ToggleAlwaysOnTop)
                             }
                         )
                     }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainAction.kt
@@ -15,4 +15,6 @@ sealed class MainAction : MVIAction {
     data object OpenSetting : MainAction()
 
     data object OpenDevice : MainAction()
+
+    data object ToggleAlwaysOnTop : MainAction()
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainState.kt
@@ -12,4 +12,5 @@ data class MainState(
     val dialog: MainDialog = MainDialog.Empty,
     val category: MainCategory = MainCategory.Command,
     val selectedDevice: Device? = null,
+    val isAlwaysOnTop: Boolean = false,
 ) : MVIState

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/MainStateHolder.kt
@@ -66,6 +66,7 @@ class MainStateHolder(
             is MainAction.OpenDevice -> openDevice()
             is MainAction.SaveSetting -> saveSetting(uiAction.windowSize)
             is MainAction.ClickCategory -> clickCategory(uiAction.category)
+            is MainAction.ToggleAlwaysOnTop -> toggleAlwaysOnTop()
         }
     }
 
@@ -83,6 +84,10 @@ class MainStateHolder(
 
     private fun clickCategory(category: MainCategory) {
         update { copy(category = category) }
+    }
+
+    private fun toggleAlwaysOnTop() {
+        update { copy(isAlwaysOnTop = !isAlwaysOnTop) }
     }
 
     private var themeFlowJob: Job? = null

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -247,6 +247,16 @@ object Language : StringResources {
     override val tooltipSetting: String
         get() = getCurrentResources().tooltipSetting
 
+    // MenuBar Window menu
+    override val menuWindow: String
+        get() = getCurrentResources().menuWindow
+    override val menuWindowMaximize: String
+        get() = getCurrentResources().menuWindowMaximize
+    override val menuWindowMinimize: String
+        get() = getCurrentResources().menuWindowMinimize
+    override val menuWindowFullscreen: String
+        get() = getCurrentResources().menuWindowFullscreen
+
     private var currentType: Type = Type.ENGLISH
 
     fun switch(type: Type) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -256,6 +256,8 @@ object Language : StringResources {
         get() = getCurrentResources().menuWindowMinimize
     override val menuWindowFullscreen: String
         get() = getCurrentResources().menuWindowFullscreen
+    override val menuWindowAlwaysOnTop: String
+        get() = getCurrentResources().menuWindowAlwaysOnTop
 
     private var currentType: Type = Type.ENGLISH
 

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -139,4 +139,5 @@ object ChineseResources : StringResources {
     override val menuWindowMaximize: String = "最大化"
     override val menuWindowMinimize: String = "最小化"
     override val menuWindowFullscreen: String = "全屏"
+    override val menuWindowAlwaysOnTop: String = "始终置顶"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -133,4 +133,10 @@ object ChineseResources : StringResources {
     override val tooltipScreenshot: String = "截图"
     override val tooltipFile: String = "文件"
     override val tooltipSetting: String = "设置"
+
+    // MenuBar Window menu
+    override val menuWindow: String = "窗口"
+    override val menuWindowMaximize: String = "最大化"
+    override val menuWindowMinimize: String = "最小化"
+    override val menuWindowFullscreen: String = "全屏"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -139,4 +139,5 @@ object EnglishResources : StringResources {
     override val menuWindowMaximize: String = "Maximize"
     override val menuWindowMinimize: String = "Minimize"
     override val menuWindowFullscreen: String = "Fullscreen"
+    override val menuWindowAlwaysOnTop: String = "Always on Top"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -133,4 +133,10 @@ object EnglishResources : StringResources {
     override val tooltipScreenshot: String = "Screenshot"
     override val tooltipFile: String = "File"
     override val tooltipSetting: String = "Setting"
+
+    // MenuBar Window menu
+    override val menuWindow: String = "Window"
+    override val menuWindowMaximize: String = "Maximize"
+    override val menuWindowMinimize: String = "Minimize"
+    override val menuWindowFullscreen: String = "Fullscreen"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -132,4 +132,10 @@ object JapaneseResources : StringResources {
     override val tooltipScreenshot: String = "スクリーンショット"
     override val tooltipFile: String = "ファイル"
     override val tooltipSetting: String = "設定"
+
+    // MenuBar Window menu
+    override val menuWindow: String = "ウィンドウ"
+    override val menuWindowMaximize: String = "最大化"
+    override val menuWindowMinimize: String = "最小化"
+    override val menuWindowFullscreen: String = "フルスクリーン"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -138,4 +138,5 @@ object JapaneseResources : StringResources {
     override val menuWindowMaximize: String = "最大化"
     override val menuWindowMinimize: String = "最小化"
     override val menuWindowFullscreen: String = "フルスクリーン"
+    override val menuWindowAlwaysOnTop: String = "常に最前面に表示"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -131,4 +131,10 @@ interface StringResources {
     val tooltipScreenshot: String
     val tooltipFile: String
     val tooltipSetting: String
+
+    // MenuBar Window menu
+    val menuWindow: String
+    val menuWindowMaximize: String
+    val menuWindowMinimize: String
+    val menuWindowFullscreen: String
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -137,4 +137,5 @@ interface StringResources {
     val menuWindowMaximize: String
     val menuWindowMinimize: String
     val menuWindowFullscreen: String
+    val menuWindowAlwaysOnTop: String
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -139,4 +139,5 @@ object TurkishResources : StringResources {
     override val menuWindowMaximize: String = "Büyüt"
     override val menuWindowMinimize: String = "Küçült"
     override val menuWindowFullscreen: String = "Tam Ekran"
+    override val menuWindowAlwaysOnTop: String = "Her Zaman Üstte"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -133,4 +133,10 @@ object TurkishResources : StringResources {
     override val tooltipScreenshot: String = "Ekran Görüntüsü"
     override val tooltipFile: String = "Dosya"
     override val tooltipSetting: String = "Ayarlar"
+
+    // MenuBar Window menu
+    override val menuWindow: String = "Pencere"
+    override val menuWindowMaximize: String = "Büyüt"
+    override val menuWindowMinimize: String = "Küçült"
+    override val menuWindowFullscreen: String = "Tam Ekran"
 }


### PR DESCRIPTION
This pull request introduces a new feature to manage window states via a MenuBar in the application, including options for maximizing, minimizing, fullscreen, and toggling "Always on Top." Additionally, it updates language resources to support translations for the new menu options. Below is a summary of the most important changes grouped by theme.

### Window State Management Enhancements:
* Added `MenuBar` with options to toggle window states (`maximize`, `minimize`, `fullscreen`, and `always on top`) in `src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt`.
* Introduced `isAlwaysOnTop` property to `MainState` and implemented logic to toggle this state in `MainStateHolder`. [[1]](diffhunk://#diff-da8768f4f66b1e242293f63c62bfdcd6473bf965b35fe3fb6537b62b3e74c3f1R15) [[2]](diffhunk://#diff-3ee8f2f735349543d993deb5a25ba170136f40f9b5abdf00ff70710e408e8fd0R69) [[3]](diffhunk://#diff-3ee8f2f735349543d993deb5a25ba170136f40f9b5abdf00ff70710e408e8fd0R89-R92)
* Added `ToggleAlwaysOnTop` action to `MainAction` to handle the "Always on Top" toggle functionality.

### Language Resource Updates:
* Expanded `StringResources` interface to include menu-related strings (`menuWindow`, `menuWindowMaximize`, `menuWindowMinimize`, `menuWindowFullscreen`, `menuWindowAlwaysOnTop`).
* Updated language-specific resources (`EnglishResources`, `ChineseResources`, `JapaneseResources`, `TurkishResources`) with translations for the new menu options. [[1]](diffhunk://#diff-ed0f482c0e642d8cb3cb91655707c86d2bfedd893b4d0a6c2c21f35122c6437fR136-R142) [[2]](diffhunk://#diff-594031841b8fb02bbafe5d12494fb8440c913435b2df7a53e2b3da6c72e4369eR136-R142) [[3]](diffhunk://#diff-2477d85a4cf96726bf08ddb8fd0be90e659bbad751dffc081d24cdd549b6c7f3R135-R141) [[4]](diffhunk://#diff-b35228af6b444eabcaa2b8f89dd8fd4c85531ac2a27b8b37ab0ba12f623d7051R136-R142)