### PR TITLE
chore: update APP_VERSION to v2.7.0

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -1,6 +1,6 @@
 package jp.kaleidot725.adbpad.domain.model.language.resources
 
-const val APP_VERSION = "v2.6.0"
+const val APP_VERSION = "v2.7.0"
 
 interface StringResources {
     val windowTitle: String


### PR DESCRIPTION
Updates the APP_VERSION constant in StringResources.kt from v2.6.0 to v2.7.0 to match the application version for the v2.7.0 release.

🤖 Generated with [Claude Code](https://claude.ai/code)