### PR TITLE
Release v2.8.0

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -1,6 +1,6 @@
 package jp.kaleidot725.adbpad.domain.model.language.resources
 
-const val APP_VERSION = "v2.7.1"
+const val APP_VERSION = "v2.8.0"
 
 interface StringResources {
     val windowTitle: String


### PR DESCRIPTION
## Release v2.8.0

### New Features 🎨
- **Accent Color Customization**: Added 7 accent color options (Blue, Purple, Green, Orange, Red, Teal, Indigo)
- **Theme Variants**: Each accent color supports both light and dark theme variations
- **Multilingual Support**: Accent color names available in English, Japanese, Chinese, and Turkish
- **Color Preview**: Dropdown menu displays color circles for easy selection

### Improvements 🔧
- Changed "Appearance" to "Theme" in settings for better consistency
- Fixed dropdown menu background transparency issues  
- Added opaque backgrounds for all dropdown menus
- Enhanced window title to display current version (AdbPad(v2.8.0))

### Technical Changes 💻
- Dynamic color scheme generation based on selected accent color
- Persistent accent color settings across app restarts
- Enhanced UI component architecture for color theming
- Complete state management integration for accent colors

### Migration Notes 📝
- Settings will automatically migrate existing configurations
- Default accent color is set to Blue for new installations
- All existing functionality remains unchanged

This release significantly enhances the user experience with customizable theming while maintaining full backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)