### PR TITLE
Move refresh button to device dropdown menu

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -69,7 +69,6 @@ private fun TopSection(
     onOpenDeviceSettings: (Device) -> Unit,
     onRefresh: () -> Unit,
 ) {
-
     Surface(
         color = MaterialTheme.colorScheme.background,
         modifier = Modifier.fillMaxWidth().height(40.dp),

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DropDownDeviceMenu.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/section/top/component/DropDownDeviceMenu.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding


### PR DESCRIPTION
## Summary
• Move refresh button from TopSection to the upper right corner of device dropdown menu  
• Add header with "Devices" title in dropdown menu for better organization
• Remove refresh button from TopSection to reduce visual clutter and improve UX
• Maintain all existing refresh functionality including animation and tooltip

## Changes
- **DropDownDeviceMenu.kt**: Added refresh button with header section in dropdown
- **TopSection.kt**: Removed refresh button and cleaned up unused imports/variables

## Test plan
- [ ] Verify device dropdown opens and shows "Devices" header with refresh button
- [ ] Test refresh button functionality (animation, tooltip, device refresh)
- [ ] Confirm TopSection no longer has refresh button
- [ ] Check that refresh button is properly positioned in upper right of dropdown

🤖 Generated with [Claude Code](https://claude.ai/code)