### PR TITLE
Refactor Setting and DeviceSettings screens to use left-right pane layout

### DIFF
--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -339,6 +339,8 @@ fun App(
                                     DeviceSettingsScreen(
                                         device = device,
                                         deviceSettings = deviceSettings,
+                                        selectedCategory = deviceSettingsState.selectedCategory,
+                                        onAction = onDeviceSettingsAction,
                                         onUpdateDeviceSettings = { settings ->
                                             onDeviceSettingsAction(DeviceSettingsAction.UpdateSettings(settings))
                                         },

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -364,6 +364,18 @@ object Language : StringResources {
     override val customTitlePlaceholder: String
         get() = getCurrentResources().customTitlePlaceholder
 
+    // Setting Categories
+    override val categoryAppearance: String
+        get() = getCurrentResources().categoryAppearance
+    override val categorySDK: String
+        get() = getCurrentResources().categorySDK
+
+    // Device Setting Categories
+    override val categoryDevice: String
+        get() = getCurrentResources().categoryDevice
+    override val categoryScrcpy: String
+        get() = getCurrentResources().categoryScrcpy
+
     private var currentType: Type = Type.ENGLISH
 
     fun switch(type: Type) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -156,7 +156,7 @@ object ChineseResources : StringResources {
     // Device Settings Screen
     override val deviceSettingsTitle: String = "设备设置"
     override val deviceNameSection: String = "设备名称"
-    override val customDeviceNameLabel: String = "自定义设备名称"
+    override val customDeviceNameLabel: String = "自定义名称"
     override val scrcpySettingsSection: String = "Scrcpy设置"
 
     // Scrcpy Options Section
@@ -196,4 +196,12 @@ object ChineseResources : StringResources {
     override val autoLabel: String = "自动"
     override val defaultLabel: String = "默认"
     override val customTitlePlaceholder: String = "自定义标题"
+
+    // Setting Categories
+    override val categoryAppearance: String = "外观"
+    override val categorySDK: String = "SDK"
+
+    // Device Setting Categories
+    override val categoryDevice: String = "设备"
+    override val categoryScrcpy: String = "Scrcpy"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -156,7 +156,7 @@ object EnglishResources : StringResources {
     // Device Settings Screen
     override val deviceSettingsTitle: String = "Device Settings"
     override val deviceNameSection: String = "Device Name"
-    override val customDeviceNameLabel: String = "Custom Device Name"
+    override val customDeviceNameLabel: String = "Custom Name"
     override val scrcpySettingsSection: String = "Scrcpy Settings"
 
     // Scrcpy Options Section
@@ -196,4 +196,12 @@ object EnglishResources : StringResources {
     override val autoLabel: String = "Auto"
     override val defaultLabel: String = "Default"
     override val customTitlePlaceholder: String = "Custom title"
+
+    // Setting Categories
+    override val categoryAppearance: String = "Appearance"
+    override val categorySDK: String = "SDK"
+
+    // Device Setting Categories
+    override val categoryDevice: String = "Device"
+    override val categoryScrcpy: String = "Scrcpy"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -155,7 +155,7 @@ object JapaneseResources : StringResources {
     // Device Settings Screen
     override val deviceSettingsTitle: String = "デバイス設定"
     override val deviceNameSection: String = "デバイス名"
-    override val customDeviceNameLabel: String = "カスタムデバイス名"
+    override val customDeviceNameLabel: String = "カスタム名称"
     override val scrcpySettingsSection: String = "Scrcpy設定"
 
     // Scrcpy Options Section
@@ -195,4 +195,12 @@ object JapaneseResources : StringResources {
     override val autoLabel: String = "自動"
     override val defaultLabel: String = "デフォルト"
     override val customTitlePlaceholder: String = "カスタムタイトル"
+
+    // Setting Categories
+    override val categoryAppearance: String = "外観"
+    override val categorySDK: String = "SDK"
+
+    // Device Setting Categories
+    override val categoryDevice: String = "デバイス"
+    override val categoryScrcpy: String = "Scrcpy"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -194,4 +194,12 @@ interface StringResources {
     val autoLabel: String
     val defaultLabel: String
     val customTitlePlaceholder: String
+
+    // Setting Categories
+    val categoryAppearance: String
+    val categorySDK: String
+
+    // Device Setting Categories
+    val categoryDevice: String
+    val categoryScrcpy: String
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -156,7 +156,7 @@ object TurkishResources : StringResources {
     // Device Settings Screen
     override val deviceSettingsTitle: String = "Cihaz Ayarları"
     override val deviceNameSection: String = "Cihaz Adı"
-    override val customDeviceNameLabel: String = "Özel Cihaz Adı"
+    override val customDeviceNameLabel: String = "Özel Ad"
     override val scrcpySettingsSection: String = "Scrcpy Ayarları"
 
     // Scrcpy Options Section
@@ -196,4 +196,12 @@ object TurkishResources : StringResources {
     override val autoLabel: String = "Otomatik"
     override val defaultLabel: String = "Varsayılan"
     override val customTitlePlaceholder: String = "Özel başlık"
+
+    // Setting Categories
+    override val categoryAppearance: String = "Görünüm"
+    override val categorySDK: String = "SDK"
+
+    // Device Setting Categories
+    override val categoryDevice: String = "Cihaz"
+    override val categoryScrcpy: String = "Scrcpy"
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsScreen.kt
@@ -2,20 +2,16 @@ package jp.kaleidot725.adbpad.ui.screen.device
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,15 +21,18 @@ import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.device.DeviceSettings
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.component.button.FloatingDialog
-import jp.kaleidot725.adbpad.ui.component.text.DefaultOutlineTextField
-import jp.kaleidot725.adbpad.ui.component.text.SubTitle
-import jp.kaleidot725.adbpad.ui.component.text.Title
-import jp.kaleidot725.adbpad.ui.screen.device.section.ScrcpyOptionsSection
+import jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory
+import jp.kaleidot725.adbpad.ui.screen.device.section.DeviceCategorySidebar
+import jp.kaleidot725.adbpad.ui.screen.device.section.DeviceGeneralPane
+import jp.kaleidot725.adbpad.ui.screen.device.section.DeviceScrcpyPane
+import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsAction
 
 @Composable
 fun DeviceSettingsScreen(
     device: Device,
     deviceSettings: DeviceSettings,
+    selectedCategory: DeviceSettingCategory,
+    onAction: (DeviceSettingsAction) -> Unit,
     onUpdateDeviceSettings: (DeviceSettings) -> Unit,
     onSave: () -> Unit,
     onCancel: () -> Unit,
@@ -43,68 +42,42 @@ fun DeviceSettingsScreen(
     FloatingDialog(
         modifier =
             modifier
-                .width(800.dp)
+                .width(1000.dp)
                 .fillMaxHeight()
                 .padding(vertical = 32.dp),
     ) {
-        Box(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .padding(bottom = 80.dp),
-            ) {
-                Title(
-                    text = "${Language.deviceSettingsTitle} - ${device.displayName}",
-                    modifier = Modifier.fillMaxWidth(),
+        Box(modifier = Modifier.fillMaxSize()) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                DeviceCategorySidebar(
+                    categories = DeviceSettingCategory.entries,
+                    selectedCategory = selectedCategory,
+                    onCategorySelected = { onAction(DeviceSettingsAction.SelectCategory(it)) },
                 )
 
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
+                VerticalDivider()
 
-                // Device Name Section
-                SubTitle(
-                    text = Language.deviceNameSection,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                DefaultOutlineTextField(
-                    id = device.serial,
-                    initialText = deviceSettings.customName ?: device.name,
-                    onUpdateText = { newName ->
-                        onUpdateDeviceSettings(
-                            deviceSettings.copy(
-                                customName = if (newName.isNotBlank() && newName != device.name) newName else null,
-                            ),
+                when (selectedCategory) {
+                    DeviceSettingCategory.DEVICE -> {
+                        DeviceGeneralPane(
+                            device = device,
+                            deviceSettings = deviceSettings,
+                            onUpdateDeviceSettings = onUpdateDeviceSettings,
+                            modifier = Modifier.weight(1f),
                         )
-                    },
-                    label = Language.customDeviceNameLabel,
-                    placeHolder = device.name,
-                    isError = false,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-                // Scrcpy Settings Section
-                SubTitle(
-                    text = Language.scrcpySettingsSection,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                ScrcpyOptionsSection(
-                    scrcpyOptions = deviceSettings.scrcpyOptions,
-                    onUpdateOptions = { newOptions ->
-                        onUpdateDeviceSettings(deviceSettings.copy(scrcpyOptions = newOptions))
-                    },
-                )
+                    }
+                    DeviceSettingCategory.SCRCPY -> {
+                        DeviceScrcpyPane(
+                            deviceSettings = deviceSettings,
+                            onUpdateDeviceSettings = onUpdateDeviceSettings,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
             }
 
-            // Action Buttons
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.align(Alignment.BottomEnd),
+                modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
             ) {
                 Button(
                     onClick = onCancel,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
@@ -26,6 +26,7 @@ class DeviceSettingsStateHolder(
 
     override fun onAction(uiAction: DeviceSettingsAction) {
         when (uiAction) {
+            is DeviceSettingsAction.SelectCategory -> selectCategory(uiAction.category)
             is DeviceSettingsAction.UpdateSettings -> updateSettings(uiAction.settings)
             is DeviceSettingsAction.Save -> saveSettings()
             is DeviceSettingsAction.Cancel -> cancel()
@@ -68,5 +69,9 @@ class DeviceSettingsStateHolder(
 
     private fun cancel() {
         sideEffect(DeviceSettingsSideEffect.Cancelled)
+    }
+
+    private fun selectCategory(category: jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory) {
+        update { this.copy(selectedCategory = category) }
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/model/DeviceSettingCategory.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/model/DeviceSettingCategory.kt
@@ -1,0 +1,16 @@
+package jp.kaleidot725.adbpad.ui.screen.device.model
+
+import jp.kaleidot725.adbpad.domain.model.language.Language
+
+enum class DeviceSettingCategory {
+    DEVICE,
+    SCRCPY,
+    ;
+
+    val displayName: String
+        get() =
+            when (this) {
+                DEVICE -> Language.categoryDevice
+                SCRCPY -> Language.categoryScrcpy
+            }
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/section/DeviceCategorySidebar.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/section/DeviceCategorySidebar.kt
@@ -1,0 +1,80 @@
+package jp.kaleidot725.adbpad.ui.screen.device.section
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory
+
+@Composable
+fun DeviceCategorySidebar(
+    categories: List<DeviceSettingCategory>,
+    selectedCategory: DeviceSettingCategory,
+    onCategorySelected: (DeviceSettingCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .width(200.dp)
+                .fillMaxHeight()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        categories.forEach { category ->
+            CategoryItem(
+                category = category,
+                isSelected = category == selectedCategory,
+                onClick = { onCategorySelected(category) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryItem(
+    category: DeviceSettingCategory,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        }
+
+    val textColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+
+    Text(
+        text = category.displayName,
+        color = textColor,
+        fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(backgroundColor)
+                .clickable { onClick() }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+    )
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/section/DeviceGeneralPane.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/section/DeviceGeneralPane.kt
@@ -1,0 +1,56 @@
+package jp.kaleidot725.adbpad.ui.screen.device.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.domain.model.device.Device
+import jp.kaleidot725.adbpad.domain.model.device.DeviceSettings
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.component.text.DefaultOutlineTextField
+import jp.kaleidot725.adbpad.ui.component.text.SubTitle
+
+@Composable
+fun DeviceGeneralPane(
+    device: Device,
+    deviceSettings: DeviceSettings,
+    onUpdateDeviceSettings: (DeviceSettings) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp)
+                .padding(bottom = 100.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        SubTitle(
+            text = Language.customDeviceNameLabel,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        DefaultOutlineTextField(
+            id = device.serial,
+            initialText = deviceSettings.customName ?: device.name,
+            onUpdateText = { newName ->
+                onUpdateDeviceSettings(
+                    deviceSettings.copy(
+                        customName = if (newName.isNotBlank() && newName != device.name) newName else null,
+                    ),
+                )
+            },
+            label = Language.customDeviceNameLabel,
+            placeHolder = device.name,
+            isError = false,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/section/DeviceScrcpyPane.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/section/DeviceScrcpyPane.kt
@@ -5,16 +5,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,9 +26,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import jp.kaleidot725.adbpad.domain.model.device.ScrcpyOptions
+import jp.kaleidot725.adbpad.domain.model.device.DeviceSettings
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.component.text.DefaultOutlineTextField
+import jp.kaleidot725.adbpad.ui.component.text.SubTitle
 import jp.kaleidot725.scrcpykt.option.AudioCodec
 import jp.kaleidot725.scrcpykt.option.AudioSource
 import jp.kaleidot725.scrcpykt.option.LogLevel
@@ -35,19 +37,29 @@ import jp.kaleidot725.scrcpykt.option.VideoCodec
 import jp.kaleidot725.scrcpykt.option.VideoSource
 
 @Composable
-fun ScrcpyOptionsSection(
-    scrcpyOptions: ScrcpyOptions,
-    onUpdateOptions: (ScrcpyOptions) -> Unit,
+fun DeviceScrcpyPane(
+    deviceSettings: DeviceSettings,
+    onUpdateDeviceSettings: (DeviceSettings) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(24.dp)
+                .padding(bottom = 100.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = modifier,
     ) {
+        val scrcpyOptions = deviceSettings.scrcpyOptions
+        val onUpdateOptions = { newOptions: jp.kaleidot725.adbpad.domain.model.device.ScrcpyOptions ->
+            onUpdateDeviceSettings(deviceSettings.copy(scrcpyOptions = newOptions))
+        }
+
         // Video Options
-        Text(
+        SubTitle(
             text = Language.videoOptionsSection,
-            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 4.dp),
         )
 
         // No Video checkbox first
@@ -130,12 +142,10 @@ fun ScrcpyOptionsSection(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
         // Audio Options
-        Text(
+        SubTitle(
             text = Language.audioOptionsSection,
-            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 4.dp),
         )
 
         Row(
@@ -203,12 +213,10 @@ fun ScrcpyOptionsSection(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
         // Display Options
-        Text(
+        SubTitle(
             text = Language.displayOptionsSection,
-            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 4.dp),
         )
 
         // Window Title
@@ -314,12 +322,10 @@ fun ScrcpyOptionsSection(
             }
         }
 
-        HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
         // Control Options
-        Text(
+        SubTitle(
             text = Language.controlOptionsSection,
-            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 4.dp),
         )
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -379,12 +385,10 @@ fun ScrcpyOptionsSection(
             }
         }
 
-        HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
         // Logging Options
-        Text(
+        SubTitle(
             text = Language.loggingOptionsSection,
-            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(horizontal = 4.dp),
         )
 
         // Log Level Dropdown

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/state/DeviceSettingsAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/state/DeviceSettingsAction.kt
@@ -2,8 +2,11 @@ package jp.kaleidot725.adbpad.ui.screen.device.state
 
 import jp.kaleidot725.adbpad.core.mvi.MVIAction
 import jp.kaleidot725.adbpad.domain.model.device.DeviceSettings
+import jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory
 
 sealed class DeviceSettingsAction : MVIAction {
+    data class SelectCategory(val category: DeviceSettingCategory) : DeviceSettingsAction()
+
     data class UpdateSettings(val settings: DeviceSettings) : DeviceSettingsAction()
 
     data object Save : DeviceSettingsAction()

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/state/DeviceSettingsState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/device/state/DeviceSettingsState.kt
@@ -3,10 +3,12 @@ package jp.kaleidot725.adbpad.ui.screen.device.state
 import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.device.DeviceSettings
+import jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory
 
 data class DeviceSettingsState(
     val device: Device? = null,
     val deviceSettings: DeviceSettings? = null,
+    val selectedCategory: DeviceSettingCategory = DeviceSettingCategory.DEVICE,
     val isLoaded: Boolean = false,
     val isSaving: Boolean = false,
 ) : MVIState {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingScreen.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingScreen.kt
@@ -2,33 +2,27 @@ package jp.kaleidot725.adbpad.ui.screen.setting
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.language.Language
-import jp.kaleidot725.adbpad.domain.model.setting.AccentColor
-import jp.kaleidot725.adbpad.domain.model.setting.Appearance
 import jp.kaleidot725.adbpad.ui.component.button.FloatingDialog
-import jp.kaleidot725.adbpad.ui.component.button.RadioButtons
-import jp.kaleidot725.adbpad.ui.component.text.DefaultOutlineTextField
-import jp.kaleidot725.adbpad.ui.component.text.SubTitle
-import jp.kaleidot725.adbpad.ui.component.text.Title
-import jp.kaleidot725.adbpad.ui.screen.setting.component.AccentColorDropButton
-import jp.kaleidot725.adbpad.ui.screen.setting.component.LanguageDropButton
+import jp.kaleidot725.adbpad.ui.screen.setting.model.SettingCategory
+import jp.kaleidot725.adbpad.ui.screen.setting.section.AppearanceSettingsPane
+import jp.kaleidot725.adbpad.ui.screen.setting.section.CategorySidebar
+import jp.kaleidot725.adbpad.ui.screen.setting.section.SdkPathSettingsPane
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingAction
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingState
 
@@ -38,57 +32,6 @@ fun SettingScreen(
     onAction: (SettingAction) -> Unit,
     onMainRefresh: () -> Unit,
 ) {
-    SettingScreen(
-        initialized = state.initialized,
-        languages = state.languages,
-        selectLanguage = state.selectedLanguage,
-        onUpdateLanguage = { onAction(SettingAction.UpdateLanguage(it)) },
-        appearance = state.appearance,
-        updateAppearance = { onAction(SettingAction.UpdateAppearance(it)) },
-        accentColor = state.accentColor,
-        onUpdateAccentColor = { onAction(SettingAction.UpdateAccentColor(it)) },
-        adbDirectoryPath = state.adbDirectoryPath,
-        onChangeAdbDirectoryPath = { onAction(SettingAction.UpdateAdbDirectoryPath(it)) },
-        isValidAdbDirectoryPath = state.isValidAdbDirectoryPath,
-        adbPortNumber = state.adbPortNumber,
-        onChangeAdbPortNumber = { onAction(SettingAction.UpdateAdbPortNumberPath(it)) },
-        isValidAdbPortNumber = state.isValidAdbPortNumber,
-        scrcpyBinaryPath = state.scrcpyBinaryPath,
-        onChangeScrcpyBinaryPath = { onAction(SettingAction.UpdateScrcpyBinaryPath(it)) },
-        isValidScrcpyBinaryPath = state.isValidScrcpyBinaryPath,
-        onSave = { onAction(SettingAction.Save) },
-        canSave = state.canSave,
-        isSaving = state.isSaving,
-        onCancel = { onMainRefresh() },
-        canCancel = state.canCancel,
-    )
-}
-
-@Composable
-fun SettingScreen(
-    initialized: Boolean,
-    languages: List<Language.Type>,
-    selectLanguage: Language.Type,
-    onUpdateLanguage: (Language.Type) -> Unit,
-    appearance: Appearance,
-    updateAppearance: (Appearance) -> Unit,
-    accentColor: AccentColor,
-    onUpdateAccentColor: (AccentColor) -> Unit,
-    adbDirectoryPath: String,
-    onChangeAdbDirectoryPath: (String) -> Unit,
-    isValidAdbDirectoryPath: Boolean,
-    adbPortNumber: String,
-    onChangeAdbPortNumber: (String) -> Unit,
-    isValidAdbPortNumber: Boolean,
-    scrcpyBinaryPath: String,
-    onChangeScrcpyBinaryPath: (String) -> Unit,
-    isValidScrcpyBinaryPath: Boolean,
-    onSave: () -> Unit,
-    canSave: Boolean,
-    isSaving: Boolean,
-    onCancel: () -> Unit,
-    canCancel: Boolean,
-) {
     FloatingDialog(
         modifier =
             Modifier
@@ -96,114 +39,61 @@ fun SettingScreen(
                 .fillMaxHeight()
                 .padding(vertical = 32.dp),
     ) {
-        if (!initialized) {
+        if (!state.initialized) {
             Box(modifier = Modifier.fillMaxSize()) {
                 CircularProgressIndicator()
             }
             return@FloatingDialog
         }
 
-        Box(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Title(text = Language.setting, modifier = Modifier.fillMaxWidth())
-
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-                SubTitle(
-                    text = Language.settingLanguageHeader,
-                    modifier = Modifier.padding(horizontal = 4.dp),
+        Box(modifier = Modifier.fillMaxSize()) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                CategorySidebar(
+                    categories = SettingCategory.entries,
+                    selectedCategory = state.selectedCategory,
+                    onCategorySelected = { onAction(SettingAction.SelectCategory(it)) },
                 )
 
-                LanguageDropButton(
-                    languages = languages,
-                    selectedLanguage = selectLanguage,
-                    onSelect = onUpdateLanguage,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
+                VerticalDivider()
 
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-                SubTitle(
-                    text = Language.settingThemeHeader,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                RadioButtons(
-                    selectedItem = appearance.value,
-                    items = Appearance.entries.map { it.value },
-                    onSelect = { value -> updateAppearance(Appearance.entries.first { it.value == value }) },
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
-                )
-
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-                SubTitle(
-                    text = Language.settingAccentColorHeader,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                AccentColorDropButton(
-                    accentColors = AccentColor.entries,
-                    selectedAccentColor = accentColor,
-                    onSelect = onUpdateAccentColor,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-                SubTitle(
-                    text = Language.settingAdbHeader,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                DefaultOutlineTextField(
-                    id = initialized,
-                    initialText = adbDirectoryPath,
-                    onUpdateText = onChangeAdbDirectoryPath,
-                    label = Language.settingAdbDirectoryPathTitle,
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = !isValidAdbDirectoryPath,
-                    placeHolder = "",
-                )
-
-                DefaultOutlineTextField(
-                    id = initialized,
-                    initialText = adbPortNumber,
-                    onUpdateText = onChangeAdbPortNumber,
-                    label = Language.settingAdbPortNumberTitle,
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = !isValidAdbPortNumber,
-                    placeHolder = "",
-                )
-
-                HorizontalDivider(modifier = Modifier.fillMaxWidth())
-
-                SubTitle(
-                    text = Language.settingScrcpyHeader,
-                    modifier = Modifier.padding(horizontal = 4.dp),
-                )
-
-                DefaultOutlineTextField(
-                    id = initialized,
-                    initialText = scrcpyBinaryPath,
-                    onUpdateText = onChangeScrcpyBinaryPath,
-                    label = Language.settingScrcpyBinaryPathTitle,
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = !isValidScrcpyBinaryPath,
-                    placeHolder = "",
-                )
+                when (state.selectedCategory) {
+                    SettingCategory.APPEARANCE -> {
+                        AppearanceSettingsPane(
+                            languages = state.languages,
+                            selectedLanguage = state.selectedLanguage,
+                            onUpdateLanguage = { onAction(SettingAction.UpdateLanguage(it)) },
+                            appearance = state.appearance,
+                            onUpdateAppearance = { onAction(SettingAction.UpdateAppearance(it)) },
+                            accentColor = state.accentColor,
+                            onUpdateAccentColor = { onAction(SettingAction.UpdateAccentColor(it)) },
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                    SettingCategory.SDK -> {
+                        SdkPathSettingsPane(
+                            initialized = state.initialized,
+                            adbDirectoryPath = state.adbDirectoryPath,
+                            onChangeAdbDirectoryPath = { onAction(SettingAction.UpdateAdbDirectoryPath(it)) },
+                            isValidAdbDirectoryPath = state.isValidAdbDirectoryPath,
+                            adbPortNumber = state.adbPortNumber,
+                            onChangeAdbPortNumber = { onAction(SettingAction.UpdateAdbPortNumberPath(it)) },
+                            isValidAdbPortNumber = state.isValidAdbPortNumber,
+                            scrcpyBinaryPath = state.scrcpyBinaryPath,
+                            onChangeScrcpyBinaryPath = { onAction(SettingAction.UpdateScrcpyBinaryPath(it)) },
+                            isValidScrcpyBinaryPath = state.isValidScrcpyBinaryPath,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
             }
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.align(Alignment.BottomEnd),
+                modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
             ) {
                 Button(
-                    onClick = onCancel,
-                    enabled = canCancel,
+                    onClick = onMainRefresh,
+                    enabled = state.canCancel,
                 ) {
                     Text(
                         text = Language.cancel,
@@ -212,10 +102,10 @@ fun SettingScreen(
                     )
                 }
                 Button(
-                    onClick = onSave,
-                    enabled = canSave,
+                    onClick = { onAction(SettingAction.Save) },
+                    enabled = state.canSave,
                 ) {
-                    if (isSaving) {
+                    if (state.isSaving) {
                         Box(
                             modifier = Modifier.width(100.dp),
                         ) {

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
@@ -68,6 +68,7 @@ class SettingStateHolder(
         coroutineScope.launch {
             when (uiAction) {
                 SettingAction.Save -> save()
+                is SettingAction.SelectCategory -> selectCategory(uiAction.category)
                 is SettingAction.UpdateAdbDirectoryPath -> updateAdbDirectoryPath(uiAction.value)
                 is SettingAction.UpdateAdbPortNumberPath -> updateAdbPortNumberPath(uiAction.value)
                 is SettingAction.UpdateScrcpyBinaryPath -> updateScrcpyBinaryPath(uiAction.value)
@@ -113,5 +114,9 @@ class SettingStateHolder(
 
     private fun updateAccentColor(value: AccentColor) {
         update { this.copy(accentColor = value) }
+    }
+
+    private fun selectCategory(category: jp.kaleidot725.adbpad.ui.screen.setting.model.SettingCategory) {
+        update { this.copy(selectedCategory = category) }
     }
 }

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/AccentColorDropButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/AccentColorDropButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -47,7 +48,7 @@ fun AccentColorDropButton(
         Row(
             modifier =
                 Modifier
-                    .width(200.dp)
+                    .fillMaxWidth()
                     .defaultBorder()
                     .clip(RoundedCornerShape(4.dp))
                     .clickableBackground()
@@ -89,8 +90,7 @@ fun AccentColorDropButton(
                     .background(
                         color = UserColor.getDropdownBackgroundColor(),
                         shape = RoundedCornerShape(4.dp),
-                    )
-                    .border(
+                    ).border(
                         width = 1.dp,
                         color = UserColor.getSplitterColor(),
                         shape = RoundedCornerShape(4.dp),

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/LanguageDropButton.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/LanguageDropButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,7 +43,7 @@ fun LanguageDropButton(
         Row(
             modifier =
                 Modifier
-                    .width(200.dp)
+                    .fillMaxWidth()
                     .defaultBorder()
                     .clip(RoundedCornerShape(4.dp))
                     .clickableBackground()
@@ -70,8 +71,7 @@ fun LanguageDropButton(
                     .background(
                         color = UserColor.getDropdownBackgroundColor(),
                         shape = RoundedCornerShape(4.dp),
-                    )
-                    .border(
+                    ).border(
                         width = 1.dp,
                         color = UserColor.getSplitterColor(),
                         shape = RoundedCornerShape(4.dp),

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/model/SettingCategory.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/model/SettingCategory.kt
@@ -1,0 +1,16 @@
+package jp.kaleidot725.adbpad.ui.screen.setting.model
+
+import jp.kaleidot725.adbpad.domain.model.language.Language
+
+enum class SettingCategory {
+    APPEARANCE,
+    SDK,
+    ;
+
+    val displayName: String
+        get() =
+            when (this) {
+                APPEARANCE -> Language.categoryAppearance
+                SDK -> Language.categorySDK
+            }
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/section/AppearanceSettingsPane.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/section/AppearanceSettingsPane.kt
@@ -1,0 +1,77 @@
+package jp.kaleidot725.adbpad.ui.screen.setting.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.domain.model.setting.AccentColor
+import jp.kaleidot725.adbpad.domain.model.setting.Appearance
+import jp.kaleidot725.adbpad.ui.component.button.RadioButtons
+import jp.kaleidot725.adbpad.ui.component.text.SubTitle
+import jp.kaleidot725.adbpad.ui.screen.setting.component.AccentColorDropButton
+import jp.kaleidot725.adbpad.ui.screen.setting.component.LanguageDropButton
+
+@Composable
+fun AppearanceSettingsPane(
+    languages: List<Language.Type>,
+    selectedLanguage: Language.Type,
+    onUpdateLanguage: (Language.Type) -> Unit,
+    appearance: Appearance,
+    onUpdateAppearance: (Appearance) -> Unit,
+    accentColor: AccentColor,
+    onUpdateAccentColor: (AccentColor) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = 100.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        SubTitle(
+            text = Language.settingLanguageHeader,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        LanguageDropButton(
+            languages = languages,
+            selectedLanguage = selectedLanguage,
+            onSelect = onUpdateLanguage,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+        )
+
+        SubTitle(
+            text = Language.settingThemeHeader,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        RadioButtons(
+            selectedItem = appearance.value,
+            items = Appearance.entries.map { it.value },
+            onSelect = { value -> onUpdateAppearance(Appearance.entries.first { it.value == value }) },
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+        )
+
+        SubTitle(
+            text = Language.settingAccentColorHeader,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        AccentColorDropButton(
+            accentColors = AccentColor.entries,
+            selectedAccentColor = accentColor,
+            onSelect = onUpdateAccentColor,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+        )
+    }
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/section/CategorySidebar.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/section/CategorySidebar.kt
@@ -1,0 +1,80 @@
+package jp.kaleidot725.adbpad.ui.screen.setting.section
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.ui.screen.setting.model.SettingCategory
+
+@Composable
+fun CategorySidebar(
+    categories: List<SettingCategory>,
+    selectedCategory: SettingCategory,
+    onCategorySelected: (SettingCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .width(200.dp)
+                .fillMaxHeight()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        categories.forEach { category ->
+            CategoryItem(
+                category = category,
+                isSelected = category == selectedCategory,
+                onClick = { onCategorySelected(category) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryItem(
+    category: SettingCategory,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surface
+        }
+
+    val textColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+
+    Text(
+        text = category.displayName,
+        color = textColor,
+        fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(backgroundColor)
+                .clickable { onClick() }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+    )
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/section/SdkPathSettingsPane.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/section/SdkPathSettingsPane.kt
@@ -1,0 +1,80 @@
+package jp.kaleidot725.adbpad.ui.screen.setting.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.component.text.DefaultOutlineTextField
+import jp.kaleidot725.adbpad.ui.component.text.SubTitle
+
+@Composable
+fun SdkPathSettingsPane(
+    initialized: Boolean,
+    adbDirectoryPath: String,
+    onChangeAdbDirectoryPath: (String) -> Unit,
+    isValidAdbDirectoryPath: Boolean,
+    adbPortNumber: String,
+    onChangeAdbPortNumber: (String) -> Unit,
+    isValidAdbPortNumber: Boolean,
+    scrcpyBinaryPath: String,
+    onChangeScrcpyBinaryPath: (String) -> Unit,
+    isValidScrcpyBinaryPath: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(24.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = 100.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        SubTitle(
+            text = Language.settingAdbHeader,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        DefaultOutlineTextField(
+            id = initialized,
+            initialText = adbDirectoryPath,
+            onUpdateText = onChangeAdbDirectoryPath,
+            label = Language.settingAdbDirectoryPathTitle,
+            modifier = Modifier.fillMaxWidth(),
+            isError = !isValidAdbDirectoryPath,
+            placeHolder = "",
+        )
+
+        DefaultOutlineTextField(
+            id = initialized,
+            initialText = adbPortNumber,
+            onUpdateText = onChangeAdbPortNumber,
+            label = Language.settingAdbPortNumberTitle,
+            modifier = Modifier.fillMaxWidth(),
+            isError = !isValidAdbPortNumber,
+            placeHolder = "",
+        )
+
+        SubTitle(
+            text = Language.settingScrcpyHeader,
+            modifier = Modifier.padding(horizontal = 4.dp),
+        )
+
+        DefaultOutlineTextField(
+            id = initialized,
+            initialText = scrcpyBinaryPath,
+            onUpdateText = onChangeScrcpyBinaryPath,
+            label = Language.settingScrcpyBinaryPathTitle,
+            modifier = Modifier.fillMaxWidth(),
+            isError = !isValidScrcpyBinaryPath,
+            placeHolder = "",
+        )
+    }
+}

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingAction.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingAction.kt
@@ -4,9 +4,14 @@ import jp.kaleidot725.adbpad.core.mvi.MVIAction
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.AccentColor
 import jp.kaleidot725.adbpad.domain.model.setting.Appearance
+import jp.kaleidot725.adbpad.ui.screen.setting.model.SettingCategory
 
 sealed class SettingAction : MVIAction {
     data object Save : SettingAction()
+
+    data class SelectCategory(
+        val category: SettingCategory,
+    ) : SettingAction()
 
     data class UpdateLanguage(
         val value: Language.Type,

--- a/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingState.kt
+++ b/src/jvmMain/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingState.kt
@@ -4,9 +4,11 @@ import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.setting.AccentColor
 import jp.kaleidot725.adbpad.domain.model.setting.Appearance
+import jp.kaleidot725.adbpad.ui.screen.setting.model.SettingCategory
 
 data class SettingState(
     val initialized: Boolean = false,
+    val selectedCategory: SettingCategory = SettingCategory.APPEARANCE,
     val languages: List<Language.Type> = Language.Type.entries,
     val selectedLanguage: Language.Type = Language.Type.ENGLISH,
     val appearance: Appearance = Appearance.DARK,


### PR DESCRIPTION
## Summary
- Refactored Setting and DeviceSettings screens to use left-right pane layout for improved scalability
- Added category-based navigation with sidebar for better organization
- Enhanced UI consistency and user experience

## Changes Made
- **Left Sidebar Navigation**: Added category selection with "Appearance/SDK" for Settings and "Device/Scrcpy" for DeviceSettings
- **Pane-based Content**: Separated settings into dedicated panes for each category
- **State Management**: Added category selection state and actions
- **Multilingual Support**: Updated string resources with category names for all supported languages
- **Component Integration**: Merged ScrcpyOptionsSection directly into DeviceScrcpyPane
- **UI Improvements**: Added VerticalDividers, full-width dropdowns, proper spacing, and scroll margins
- **Consistency**: Unified title styles using SubTitle components across all sections

## Test plan
- [ ] Verify Settings screen shows Appearance and SDK categories in left sidebar
- [ ] Verify DeviceSettings screen shows Device and Scrcpy categories in left sidebar
- [ ] Test category switching functionality
- [ ] Confirm all settings are properly displayed in their respective panes
- [ ] Verify multilingual support for category names
- [ ] Test dropdown components with full-width behavior
- [ ] Ensure proper scrolling behavior with bottom margins

🤖 Generated with [Claude Code](https://claude.ai/code)