### PR TITLE
feat: add command layout toggle between Card and List views

### DIFF
--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandScreen.kt
@@ -2,19 +2,23 @@ package jp.kaleidot725.adbpad.ui.screen
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommand
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandGroup
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
+import jp.kaleidot725.adbpad.ui.screen.command.component.CommandLayoutToggle
 import jp.kaleidot725.adbpad.ui.screen.command.component.CommandList
 import jp.kaleidot725.adbpad.ui.screen.command.component.CommandTab
+import jp.kaleidot725.adbpad.ui.screen.command.model.CommandLayoutMode
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandState
 
@@ -26,7 +30,9 @@ fun CommandScreen(
     CommandScreen(
         commands = state.commands,
         filtered = state.filtered,
+        layoutMode = state.layoutMode,
         onClickFilter = { onAction(CommandAction.ClickCategoryTab(it)) },
+        onToggleLayout = { onAction(CommandAction.ToggleLayoutMode) },
         canExecute = state.canExecuteCommand,
         onExecute = { command -> onAction(CommandAction.ExecuteCommand(command)) },
     )
@@ -36,16 +42,28 @@ fun CommandScreen(
 private fun CommandScreen(
     commands: NormalCommandGroup,
     filtered: NormalCommandCategory,
+    layoutMode: CommandLayoutMode,
     onClickFilter: (NormalCommandCategory) -> Unit,
+    onToggleLayout: () -> Unit,
     canExecute: Boolean,
     onExecute: (NormalCommand) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
-        CommandTab(
-            filtered = filtered,
-            onClick = onClickFilter,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.height(48.dp).padding(8.dp),
-        )
+        ) {
+            CommandTab(
+                filtered = filtered,
+                onClick = onClickFilter,
+                modifier = Modifier.weight(1f),
+            )
+
+            CommandLayoutToggle(
+                layoutMode = layoutMode,
+                onToggle = onToggleLayout,
+            )
+        }
 
         Divider(color = UserColor.getSplitterColor())
 
@@ -58,6 +76,7 @@ private fun CommandScreen(
                 },
             canExecute = canExecute,
             onExecute = onExecute,
+            layoutMode = layoutMode,
             modifier = Modifier.fillMaxSize().padding(16.dp),
         )
     }
@@ -65,7 +84,7 @@ private fun CommandScreen(
 
 @Preview
 @Composable
-private fun CommandScreen_Preview() {
+private fun CommandScreen_Card_Preview() {
     CommandScreen(
         commands =
             NormalCommandGroup(
@@ -74,7 +93,28 @@ private fun CommandScreen_Preview() {
                 listOf(NormalCommand.WifiOn()),
             ),
         filtered = NormalCommandCategory.ALL,
+        layoutMode = CommandLayoutMode.CARD,
         onClickFilter = {},
+        onToggleLayout = {},
+        canExecute = true,
+        onExecute = {},
+    )
+}
+
+@Preview
+@Composable
+private fun CommandScreen_List_Preview() {
+    CommandScreen(
+        commands =
+            NormalCommandGroup(
+                listOf(NormalCommand.DarkThemeOn(), NormalCommand.DarkThemeOff(), NormalCommand.WifiOn()),
+                listOf(NormalCommand.DarkThemeOn(), NormalCommand.DarkThemeOff()),
+                listOf(NormalCommand.WifiOn()),
+            ),
+        filtered = NormalCommandCategory.ALL,
+        layoutMode = CommandLayoutMode.LIST,
+        onClickFilter = {},
+        onToggleLayout = {},
         canExecute = true,
         onExecute = {},
     )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
@@ -6,6 +6,7 @@ import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 import jp.kaleidot725.adbpad.domain.usecase.command.ExecuteCommandUseCase
 import jp.kaleidot725.adbpad.domain.usecase.command.GetNormalCommandGroup
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
+import jp.kaleidot725.adbpad.ui.screen.command.model.CommandLayoutMode
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandSideEffect
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandState
@@ -40,6 +41,7 @@ class CommandStateHolder(
             when (uiAction) {
                 is CommandAction.ClickCategoryTab -> clickTab(uiAction.category)
                 is CommandAction.ExecuteCommand -> executeCommand(uiAction.command)
+                is CommandAction.ToggleLayoutMode -> toggleLayoutMode()
             }
         }
     }
@@ -70,6 +72,17 @@ class CommandStateHolder(
     private fun clickTab(filtered: NormalCommandCategory) {
         update {
             this.copy(filtered = filtered)
+        }
+    }
+
+    private fun toggleLayoutMode() {
+        update {
+            val newMode =
+                when (layoutMode) {
+                    CommandLayoutMode.CARD -> CommandLayoutMode.LIST
+                    CommandLayoutMode.LIST -> CommandLayoutMode.CARD
+                }
+            this.copy(layoutMode = newMode)
         }
     }
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandItemCard.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandItemCard.kt
@@ -24,7 +24,7 @@ import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
 
 @Composable
-fun CommandItem(
+fun CommandItemCard(
     title: String,
     detail: String,
     isRunning: Boolean,
@@ -55,8 +55,8 @@ fun CommandItem(
 
 @Preview
 @Composable
-private fun CommandItem_Running_Preview() {
-    CommandItem(
+private fun CommandItemCard_Running_Preview() {
+    CommandItemCard(
         title = "ダークテーマON",
         detail = "端末のダークテーマ設定をONにします",
         isRunning = true,
@@ -68,8 +68,8 @@ private fun CommandItem_Running_Preview() {
 
 @Preview
 @Composable
-private fun CommandItem_NotRunning_Preview() {
-    CommandItem(
+private fun CommandItemCard_NotRunning_Preview() {
+    CommandItemCard(
         title = "ダークテーマON",
         detail = "端末のダークテーマ設定をONにします",
         isRunning = false,
@@ -81,8 +81,8 @@ private fun CommandItem_NotRunning_Preview() {
 
 @Preview
 @Composable
-private fun CommandItem_NotExecute_Preview() {
-    CommandItem(
+private fun CommandItemCard_NotExecute_Preview() {
+    CommandItemCard(
         title = "ダークテーマON",
         detail = "端末のダークテーマ設定をONにします",
         isRunning = false,

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandItemList.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandItemList.kt
@@ -1,0 +1,98 @@
+package jp.kaleidot725.adbpad.ui.screen.command.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
+
+@Composable
+fun CommandItemList(
+    title: String,
+    detail: String,
+    isRunning: Boolean,
+    canExecute: Boolean,
+    onExecute: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Button(
+                onClick = { onExecute() },
+                enabled = canExecute,
+                modifier = Modifier.width(100.dp),
+            ) {
+                Box(modifier = Modifier.width(60.dp), contentAlignment = Alignment.Center) {
+                    when {
+                        isRunning -> RunningIndicator()
+                        else -> Text(text = Language.execute)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CommandItemList_Running_Preview() {
+    CommandItemList(
+        title = "ダークテーマON",
+        detail = "端末のダークテーマ設定をONにします",
+        isRunning = true,
+        canExecute = true,
+        onExecute = {},
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+    )
+}
+
+@Preview
+@Composable
+private fun CommandItemList_NotRunning_Preview() {
+    CommandItemList(
+        title = "ダークテーマON",
+        detail = "端末のダークテーマ設定をONにします",
+        isRunning = false,
+        canExecute = true,
+        onExecute = {},
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+    )
+}
+
+@Preview
+@Composable
+private fun CommandItemList_NotExecute_Preview() {
+    CommandItemList(
+        title = "ダークテーマON",
+        detail = "端末のダークテーマ設定をONにします",
+        isRunning = false,
+        canExecute = false,
+        onExecute = {},
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+    )
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandItemList.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandItemList.kt
@@ -3,6 +3,7 @@ package jp.kaleidot725.adbpad.ui.screen.command.component
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -34,13 +35,22 @@ fun CommandItemList(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = title,
-                fontWeight = FontWeight.Bold,
+            Column(
                 modifier = Modifier.weight(1f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = title,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = detail,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
 
             Button(
                 onClick = { onExecute() },

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandLayoutToggle.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandLayoutToggle.kt
@@ -1,0 +1,57 @@
+package jp.kaleidot725.adbpad.ui.screen.command.component
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.ViewList
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.ui.screen.command.model.CommandLayoutMode
+
+@Composable
+fun CommandLayoutToggle(
+    layoutMode: CommandLayoutMode,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onToggle,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector =
+                when (layoutMode) {
+                    CommandLayoutMode.CARD -> Icons.Default.ViewList // Show list icon when in card mode
+                    CommandLayoutMode.LIST -> Icons.Default.GridView // Show grid icon when in list mode
+                },
+            contentDescription =
+                when (layoutMode) {
+                    CommandLayoutMode.CARD -> "Switch to List View"
+                    CommandLayoutMode.LIST -> "Switch to Card View"
+                },
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CommandLayoutToggle_Card_Preview() {
+    CommandLayoutToggle(
+        layoutMode = CommandLayoutMode.CARD,
+        onToggle = {},
+    )
+}
+
+@Preview
+@Composable
+private fun CommandLayoutToggle_List_Preview() {
+    CommandLayoutToggle(
+        layoutMode = CommandLayoutMode.LIST,
+        onToggle = {},
+    )
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandList.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandList.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,30 +21,52 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommand
 import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.screen.command.model.CommandLayoutMode
 
 @Composable
 fun CommandList(
     commands: List<NormalCommand>,
     canExecute: Boolean,
     onExecute: (NormalCommand) -> Unit,
+    layoutMode: CommandLayoutMode,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
         if (commands.isNotEmpty()) {
-            LazyVerticalGrid(
-                columns = GridCells.Adaptive(250.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(commands) { command ->
-                    CommandItem(
-                        title = command.title,
-                        detail = command.details,
-                        isRunning = command.isRunning,
-                        canExecute = canExecute,
-                        onExecute = { onExecute(command) },
-                        modifier = Modifier.height(175.dp).fillMaxWidth().padding(2.dp),
-                    )
+            when (layoutMode) {
+                CommandLayoutMode.CARD -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(250.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(commands) { command ->
+                            CommandItem(
+                                title = command.title,
+                                detail = command.details,
+                                isRunning = command.isRunning,
+                                canExecute = canExecute,
+                                onExecute = { onExecute(command) },
+                                modifier = Modifier.height(175.dp).fillMaxWidth().padding(2.dp),
+                            )
+                        }
+                    }
+                }
+                CommandLayoutMode.LIST -> {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(commands) { command ->
+                            CommandItemList(
+                                title = command.title,
+                                detail = command.details,
+                                isRunning = command.isRunning,
+                                canExecute = canExecute,
+                                onExecute = { onExecute(command) },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
                 }
             }
         } else {
@@ -56,12 +80,13 @@ fun CommandList(
 
 @Preview
 @Composable
-private fun CommandList_Preview() {
+private fun CommandList_Card_Preview() {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         CommandList(
             commands = listOf(NormalCommand.DarkThemeOn(), NormalCommand.DarkThemeOff(), NormalCommand.WifiOn()),
             canExecute = true,
             onExecute = {},
+            layoutMode = CommandLayoutMode.CARD,
             modifier = Modifier.fillMaxWidth().weight(0.5f),
         )
 
@@ -69,6 +94,29 @@ private fun CommandList_Preview() {
             commands = emptyList(),
             canExecute = true,
             onExecute = {},
+            layoutMode = CommandLayoutMode.CARD,
+            modifier = Modifier.fillMaxWidth().weight(0.5f).background(Color.LightGray),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CommandList_List_Preview() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        CommandList(
+            commands = listOf(NormalCommand.DarkThemeOn(), NormalCommand.DarkThemeOff(), NormalCommand.WifiOn()),
+            canExecute = true,
+            onExecute = {},
+            layoutMode = CommandLayoutMode.LIST,
+            modifier = Modifier.fillMaxWidth().weight(0.5f),
+        )
+
+        CommandList(
+            commands = emptyList(),
+            canExecute = true,
+            onExecute = {},
+            layoutMode = CommandLayoutMode.LIST,
             modifier = Modifier.fillMaxWidth().weight(0.5f).background(Color.LightGray),
         )
     }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandList.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandList.kt
@@ -41,7 +41,7 @@ fun CommandList(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(commands) { command ->
-                            CommandItem(
+                            CommandItemCard(
                                 title = command.title,
                                 detail = command.details,
                                 isRunning = command.isRunning,

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/model/CommandLayoutMode.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/model/CommandLayoutMode.kt
@@ -1,0 +1,6 @@
+package jp.kaleidot725.adbpad.ui.screen.command.model
+
+enum class CommandLayoutMode {
+    CARD,
+    LIST,
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/state/CommandAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/state/CommandAction.kt
@@ -12,4 +12,6 @@ sealed class CommandAction : MVIAction {
     data class ClickCategoryTab(
         val category: NormalCommandCategory,
     ) : CommandAction()
+
+    data object ToggleLayoutMode : CommandAction()
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/state/CommandState.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/state/CommandState.kt
@@ -4,11 +4,13 @@ import jp.kaleidot725.adbpad.core.mvi.MVIState
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandGroup
 import jp.kaleidot725.adbpad.domain.model.device.Device
+import jp.kaleidot725.adbpad.ui.screen.command.model.CommandLayoutMode
 
 data class CommandState(
     val commands: NormalCommandGroup = NormalCommandGroup.Empty,
     val filtered: NormalCommandCategory = NormalCommandCategory.ALL,
     val selectedDevice: Device? = null,
+    val layoutMode: CommandLayoutMode = CommandLayoutMode.CARD,
 ) : MVIState {
     val canExecuteCommand: Boolean get() = selectedDevice != null
 }


### PR DESCRIPTION
## Summary  
Implements issue #185 to add layout switching functionality to Command screen with toggle between Card View and List View.

## Features Added
• **Layout Toggle Button**: Icon button in top-right corner of Command screen header
• **Card View**: Existing grid-based layout with detailed command cards (default)
• **List View**: New horizontal compact layout with title and run button
• **State Management**: Layout mode persisted in CommandState with toggle logic
• **Responsive Design**: Both layouts maintain full functionality

## UI/UX Changes
• Toggle button shows appropriate icon (list icon in card mode, grid icon in list mode)
• Card View displays commands in adaptive grid with detailed information
• List View displays commands in vertical list with compact horizontal layout
• Smooth switching between layouts preserves selected category and state

## Technical Implementation
• `CommandLayoutMode` enum defining CARD and LIST modes
• `CommandLayoutToggle` component for layout switching UI
• `CommandItemList` component for list view representation  
• Enhanced `CommandList` to support both layout modes with conditional rendering
• Updated `CommandScreen` with layout toggle functionality in header
• Proper MVI architecture with `ToggleLayoutMode` action and state updates

## Test Plan
- [x] Build succeeds without errors
- [x] Layout toggle button appears in Command screen header
- [x] Clicking toggle switches between Card and List views
- [x] Both layouts display commands correctly
- [x] Command execution works in both layouts
- [x] Category filtering works in both layouts
- [x] Layout state persists during navigation

## Screenshots/Demo
Users can now click the layout toggle button in the top-right corner of the Command screen to switch between:
1. **Card View**: Grid layout with detailed command information
2. **List View**: Compact horizontal list layout

Closes #185

🤖 Generated with [Claude Code](https://claude.ai/code)