### PR TITLE
feat: add Android language setting commands

### DIFF
--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommand.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/command/NormalCommand.kt
@@ -195,4 +195,81 @@ interface NormalCommand {
             )
         override val category: NormalCommandCategory = NormalCommandCategory.UI
     }
+
+    data class SetLanguageJapanese(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageJapaneseTitle
+        override val details: String get() = Language.commandSetLanguageJapaneseDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale ja-JP"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
+
+    data class SetLanguageEnglish(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageEnglishTitle
+        override val details: String get() = Language.commandSetLanguageEnglishDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale en-US"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
+
+    data class SetLanguageChinese(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageChineseTitle
+        override val details: String get() = Language.commandSetLanguageChineseDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale zh-CN"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
+
+    data class SetLanguageKorean(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageKoreanTitle
+        override val details: String get() = Language.commandSetLanguageKoreanDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale ko-KR"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
+
+    data class SetLanguageSpanish(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageSpanishTitle
+        override val details: String get() = Language.commandSetLanguageSpanishDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale es-ES"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
+
+    data class SetLanguageFrench(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageFrenchTitle
+        override val details: String get() = Language.commandSetLanguageFrenchDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale fr-FR"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
+
+    data class SetLanguageGerman(override val isRunning: Boolean = false) : NormalCommand {
+        override val title: String get() = Language.commandSetLanguageGermanTitle
+        override val details: String get() = Language.commandSetLanguageGermanDetails
+        override val requests: List<ShellCommandRequest> =
+            listOf(
+                ShellCommandRequest("setprop persist.sys.locale de-DE"),
+                ShellCommandRequest("am broadcast -a android.intent.action.LOCALE_CHANGED"),
+            )
+        override val category: NormalCommandCategory = NormalCommandCategory.UI
+    }
 }

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -142,6 +142,36 @@ object Language : StringResources {
     override val commandEnableGestureNavigationDetails: String
         get() = getCurrentResources().commandEnableGestureNavigationDetails
 
+    // Language Setting Commands
+    override val commandSetLanguageJapaneseTitle: String
+        get() = getCurrentResources().commandSetLanguageJapaneseTitle
+    override val commandSetLanguageJapaneseDetails: String
+        get() = getCurrentResources().commandSetLanguageJapaneseDetails
+    override val commandSetLanguageEnglishTitle: String
+        get() = getCurrentResources().commandSetLanguageEnglishTitle
+    override val commandSetLanguageEnglishDetails: String
+        get() = getCurrentResources().commandSetLanguageEnglishDetails
+    override val commandSetLanguageChineseTitle: String
+        get() = getCurrentResources().commandSetLanguageChineseTitle
+    override val commandSetLanguageChineseDetails: String
+        get() = getCurrentResources().commandSetLanguageChineseDetails
+    override val commandSetLanguageKoreanTitle: String
+        get() = getCurrentResources().commandSetLanguageKoreanTitle
+    override val commandSetLanguageKoreanDetails: String
+        get() = getCurrentResources().commandSetLanguageKoreanDetails
+    override val commandSetLanguageSpanishTitle: String
+        get() = getCurrentResources().commandSetLanguageSpanishTitle
+    override val commandSetLanguageSpanishDetails: String
+        get() = getCurrentResources().commandSetLanguageSpanishDetails
+    override val commandSetLanguageFrenchTitle: String
+        get() = getCurrentResources().commandSetLanguageFrenchTitle
+    override val commandSetLanguageFrenchDetails: String
+        get() = getCurrentResources().commandSetLanguageFrenchDetails
+    override val commandSetLanguageGermanTitle: String
+        get() = getCurrentResources().commandSetLanguageGermanTitle
+    override val commandSetLanguageGermanDetails: String
+        get() = getCurrentResources().commandSetLanguageGermanDetails
+
     override val textCommandStartEventFormat: String
         get() = getCurrentResources().textCommandStartEventFormat
     override val textCommandEndEventFormat: String

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -77,6 +77,22 @@ object ChineseResources : StringResources {
     override val commandEnableGestureNavigationTitle: String = "手势导航 : 开启"
     override val commandEnableGestureNavigationDetails: String = "启动手势导航"
 
+    // Language Setting Commands
+    override val commandSetLanguageJapaneseTitle = "语言设置: 日本語"
+    override val commandSetLanguageJapaneseDetails = "将Android设备语言更改为日语"
+    override val commandSetLanguageEnglishTitle = "语言设置: English"
+    override val commandSetLanguageEnglishDetails = "将Android设备语言更改为英语"
+    override val commandSetLanguageChineseTitle = "语言设置: 中文"
+    override val commandSetLanguageChineseDetails = "将Android设备语言更改为中文"
+    override val commandSetLanguageKoreanTitle = "语言设置: 한국어"
+    override val commandSetLanguageKoreanDetails = "将Android设备语言更改为韩语"
+    override val commandSetLanguageSpanishTitle = "语言设置: Español"
+    override val commandSetLanguageSpanishDetails = "将Android设备语言更改为西班牙语"
+    override val commandSetLanguageFrenchTitle = "语言设置: Français"
+    override val commandSetLanguageFrenchDetails = "将Android设备语言更改为法语"
+    override val commandSetLanguageGermanTitle = "语言设置: Deutsch"
+    override val commandSetLanguageGermanDetails = "将Android设备语言更改为德语"
+
     override val textCommandStartEventFormat = "开始发送文本 「%s」"
     override val textCommandEndEventFormat = "结束发送文本 「%s」"
     override val textCommandErrorEventFormat = "发送文本失败 「%s」"

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -77,6 +77,22 @@ object EnglishResources : StringResources {
     override val commandEnableGestureNavigationTitle: String = "Gesture navigation: ON"
     override val commandEnableGestureNavigationDetails: String = "Enable gesture navigation"
 
+    // Language Setting Commands
+    override val commandSetLanguageJapaneseTitle = "Language: 日本語"
+    override val commandSetLanguageJapaneseDetails = "Change the Android device language to Japanese"
+    override val commandSetLanguageEnglishTitle = "Language: English"
+    override val commandSetLanguageEnglishDetails = "Change the Android device language to English"
+    override val commandSetLanguageChineseTitle = "Language: 中文"
+    override val commandSetLanguageChineseDetails = "Change the Android device language to Chinese"
+    override val commandSetLanguageKoreanTitle = "Language: 한국어"
+    override val commandSetLanguageKoreanDetails = "Change the Android device language to Korean"
+    override val commandSetLanguageSpanishTitle = "Language: Español"
+    override val commandSetLanguageSpanishDetails = "Change the Android device language to Spanish"
+    override val commandSetLanguageFrenchTitle = "Language: Français"
+    override val commandSetLanguageFrenchDetails = "Change the Android device language to French"
+    override val commandSetLanguageGermanTitle = "Language: Deutsch"
+    override val commandSetLanguageGermanDetails = "Change the Android device language to German"
+
     override val textCommandStartEventFormat = "Start sending text「%s」"
     override val textCommandEndEventFormat = "End sending text「%s」"
     override val textCommandErrorEventFormat = "Error sending text「%s」"

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -76,6 +76,22 @@ object JapaneseResources : StringResources {
     override val commandEnableGestureNavigationTitle: String = "ジェスチャー ナビゲーション: ON"
     override val commandEnableGestureNavigationDetails: String = "ジェスチャー ナビゲーションを有効化する"
 
+    // Language Setting Commands
+    override val commandSetLanguageJapaneseTitle = "言語設定: 日本語"
+    override val commandSetLanguageJapaneseDetails = "Androidデバイスの言語を日本語に変更します"
+    override val commandSetLanguageEnglishTitle = "言語設定: English"
+    override val commandSetLanguageEnglishDetails = "Androidデバイスの言語を英語に変更します"
+    override val commandSetLanguageChineseTitle = "言語設定: 中文"
+    override val commandSetLanguageChineseDetails = "Androidデバイスの言語を中国語に変更します"
+    override val commandSetLanguageKoreanTitle = "言語設定: 한국어"
+    override val commandSetLanguageKoreanDetails = "Androidデバイスの言語を韓国語に変更します"
+    override val commandSetLanguageSpanishTitle = "言語設定: Español"
+    override val commandSetLanguageSpanishDetails = "Androidデバイスの言語をスペイン語に変更します"
+    override val commandSetLanguageFrenchTitle = "言語設定: Français"
+    override val commandSetLanguageFrenchDetails = "Androidデバイスの言語をフランス語に変更します"
+    override val commandSetLanguageGermanTitle = "言語設定: Deutsch"
+    override val commandSetLanguageGermanDetails = "Androidデバイスの言語をドイツ語に変更します"
+
     override val textCommandStartEventFormat = "「%s」のテキスト送信を開始しました"
     override val textCommandEndEventFormat = "「%s」のテキスト送信が完了しました"
     override val textCommandErrorEventFormat = "「%s」のテキスト送信に失敗しました"

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -71,6 +71,22 @@ interface StringResources {
     val commandEnableGestureNavigationTitle: String
     val commandEnableGestureNavigationDetails: String
 
+    // Language Setting Commands
+    val commandSetLanguageJapaneseTitle: String
+    val commandSetLanguageJapaneseDetails: String
+    val commandSetLanguageEnglishTitle: String
+    val commandSetLanguageEnglishDetails: String
+    val commandSetLanguageChineseTitle: String
+    val commandSetLanguageChineseDetails: String
+    val commandSetLanguageKoreanTitle: String
+    val commandSetLanguageKoreanDetails: String
+    val commandSetLanguageSpanishTitle: String
+    val commandSetLanguageSpanishDetails: String
+    val commandSetLanguageFrenchTitle: String
+    val commandSetLanguageFrenchDetails: String
+    val commandSetLanguageGermanTitle: String
+    val commandSetLanguageGermanDetails: String
+
     val textCommandStartEventFormat: String
     val textCommandEndEventFormat: String
     val textCommandErrorEventFormat: String

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -77,6 +77,22 @@ object TurkishResources : StringResources {
     override val commandEnableGestureNavigationTitle: String = "Hareket tabanlı gezinme: AÇIK"
     override val commandEnableGestureNavigationDetails: String = "Hareket tabanlı gezinmeyi etkinleştir"
 
+    // Language Setting Commands
+    override val commandSetLanguageJapaneseTitle = "Dil ayarı: 日本語"
+    override val commandSetLanguageJapaneseDetails = "Android cihaz dilini Japonca olarak değiştir"
+    override val commandSetLanguageEnglishTitle = "Dil ayarı: English"
+    override val commandSetLanguageEnglishDetails = "Android cihaz dilini İngilizce olarak değiştir"
+    override val commandSetLanguageChineseTitle = "Dil ayarı: 中文"
+    override val commandSetLanguageChineseDetails = "Android cihaz dilini Çince olarak değiştir"
+    override val commandSetLanguageKoreanTitle = "Dil ayarı: 한국어"
+    override val commandSetLanguageKoreanDetails = "Android cihaz dilini Korece olarak değiştir"
+    override val commandSetLanguageSpanishTitle = "Dil ayarı: Español"
+    override val commandSetLanguageSpanishDetails = "Android cihaz dilini İspanyolca olarak değiştir"
+    override val commandSetLanguageFrenchTitle = "Dil ayarı: Français"
+    override val commandSetLanguageFrenchDetails = "Android cihaz dilini Fransızca olarak değiştir"
+    override val commandSetLanguageGermanTitle = "Dil ayarı: Deutsch"
+    override val commandSetLanguageGermanDetails = "Android cihaz dilini Almanca olarak değiştir"
+
     override val textCommandStartEventFormat = "「%s」 metni gönderiliyor"
     override val textCommandEndEventFormat = "「%s」 metni gönderildi"
     override val textCommandErrorEventFormat = "「%s」 metni gönderilirken hata oluştu"

--- a/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/NormalCommandRepositoryImpl.kt
+++ b/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/NormalCommandRepositoryImpl.kt
@@ -33,6 +33,13 @@ class NormalCommandRepositoryImpl : NormalCommandRepository {
             NormalCommand.EnableGestureNavigation(runningCommands.any { it is NormalCommand.EnableGestureNavigation }),
             NormalCommand.EnableTwoButtonNavigation(runningCommands.any { it is NormalCommand.EnableTwoButtonNavigation }),
             NormalCommand.EnableThreeButtonNavigation(runningCommands.any { it is NormalCommand.EnableThreeButtonNavigation }),
+            NormalCommand.SetLanguageJapanese(runningCommands.any { it is NormalCommand.SetLanguageJapanese }),
+            NormalCommand.SetLanguageEnglish(runningCommands.any { it is NormalCommand.SetLanguageEnglish }),
+            NormalCommand.SetLanguageChinese(runningCommands.any { it is NormalCommand.SetLanguageChinese }),
+            NormalCommand.SetLanguageKorean(runningCommands.any { it is NormalCommand.SetLanguageKorean }),
+            NormalCommand.SetLanguageSpanish(runningCommands.any { it is NormalCommand.SetLanguageSpanish }),
+            NormalCommand.SetLanguageFrench(runningCommands.any { it is NormalCommand.SetLanguageFrench }),
+            NormalCommand.SetLanguageGerman(runningCommands.any { it is NormalCommand.SetLanguageGerman }),
         )
 
     override suspend fun sendCommand(


### PR DESCRIPTION
## Summary
- Add Android language setting commands for 7 languages (Japanese, English, Chinese, Korean, Spanish, French, German)
- Users can now change Android device language through the Command menu by selecting a device, choosing language setting commands, and clicking "Run"
- Commands use proper ADB shell commands: `setprop persist.sys.locale <locale>` and broadcast intent for immediate effect

## Features Added
- 7 new language setting command implementations in NormalCommand.kt
- Comprehensive multi-language support across all string resources (StringResources.kt, JapaneseResources.kt, EnglishResources.kt, ChineseResources.kt, TurkishResources.kt)
- Commands integrated into NormalCommandRepositoryImpl for UI availability
- Language titles maintain native language names for user recognition
- All commands categorized under UI category for proper grouping

## Technical Implementation
- Commands execute `setprop persist.sys.locale <locale_code>` followed by `am broadcast -a android.intent.action.LOCALE_CHANGED`
- Locale codes: ja-JP, en-US, zh-CN, ko-KR, es-ES, fr-FR, de-DE
- Full build and lint compliance verified

## Test Plan
- [x] Build project successfully without compilation errors
- [x] Verify ktlint code style compliance
- [x] Commands properly registered in repository
- [x] Multi-language string resources correctly implemented

Closes #184

🤖 Generated with [Claude Code](https://claude.ai/code)