### PR TITLE
feat: move scrcpy button to top section and improve UI layout

### DIFF
--- a/main/kotlin/jp/kaleidot725/adbpad/di/StateHolderModule.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/di/StateHolderModule.kt
@@ -6,6 +6,7 @@ import jp.kaleidot725.adbpad.ui.screen.main.MainStateHolder
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotStateHolder
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingStateHolder
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandStateHolder
+import jp.kaleidot725.adbpad.ui.section.right.RightStateHolder
 import jp.kaleidot725.adbpad.ui.section.top.TopStateHolder
 import org.koin.dsl.module
 
@@ -64,6 +65,14 @@ val stateHolderModule =
         }
 
         factory {
+            RightStateHolder(
+                getSelectedDeviceFlowUseCase = get(),
+                executeDeviceControlCommandUseCase = get(),
+                launchScrcpyUseCase = get(),
+            )
+        }
+
+        factory {
             DeviceSettingsStateHolder(
                 getSelectedDeviceFlowUseCase = get(),
                 deviceSettingsRepository = get(),
@@ -83,6 +92,7 @@ val stateHolderModule =
                 getAccentColorUseCase = get(),
                 refreshUseCase = get(),
                 topStateHolder = get(),
+                rightStateHolder = get(),
                 deviceSettingsStateHolder = get(),
                 settingStateHolder = get(),
                 shutdownAppUseCase = get(),

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/component/divider/CommandIconDivider.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/component/divider/CommandIconDivider.kt
@@ -3,9 +3,12 @@ package jp.kaleidot725.adbpad.ui.component.divider
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,11 +16,11 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun CommandIconDivider(modifier: Modifier = Modifier) {
-    Divider(
+    HorizontalDivider(
         modifier =
             modifier
-                .width(9.dp)
-                .fillMaxHeight()
+                .height(9.dp)
+                .fillMaxWidth()
                 .padding(vertical = 6.dp, horizontal = 4.dp)
                 .background(MaterialTheme.colorScheme.onBackground),
     )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/component/dropbox/SearchSortDropBox.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/component/dropbox/SearchSortDropBox.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.ChevronDown
-import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Search
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
@@ -88,8 +88,7 @@ fun SearchSortDropBox(
                 .background(
                     color = UserColor.getDropdownBackgroundColor(),
                     shape = RoundedCornerShape(4.dp),
-                )
-                .border(
+                ).border(
                     width = 1.dp,
                     color = UserColor.getSplitterColor(),
                     shape = RoundedCornerShape(4.dp),

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/component/layout/ScreenLayout.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/component/layout/ScreenLayout.kt
@@ -24,6 +24,7 @@ fun ScreenLayout(
     top: @Composable () -> Unit,
     navigationRail: @Composable () -> Unit,
     content: @Composable () -> Unit,
+    right: @Composable () -> Unit,
     dialog: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -34,7 +35,9 @@ fun ScreenLayout(
             Row(modifier = Modifier.weight(0.9f, true)) {
                 Box(Modifier.background(MaterialTheme.colorScheme.background)) { navigationRail() }
                 Spacer(Modifier.width(1.dp).fillMaxHeight().border(BorderStroke(1.dp, UserColor.getSplitterColor())))
-                Box(Modifier.background(MaterialTheme.colorScheme.background)) { content() }
+                Box(Modifier.background(MaterialTheme.colorScheme.background).weight(1f)) { content() }
+                Spacer(Modifier.width(1.dp).fillMaxHeight().border(BorderStroke(1.dp, UserColor.getSplitterColor())))
+                Box(Modifier.background(MaterialTheme.colorScheme.background)) { right() }
             }
             Spacer(Modifier.height(1.dp).fillMaxWidth().border(BorderStroke(1.dp, UserColor.getSplitterColor())))
         }
@@ -54,6 +57,9 @@ private fun ScreenLayout_Preview() {
         },
         content = {
             Box(Modifier.fillMaxSize().background(androidx.compose.ui.graphics.Color.Blue))
+        },
+        right = {
+            Box(Modifier.width(60.dp).fillMaxHeight().background(androidx.compose.ui.graphics.Color.Green))
         },
         dialog = {
         },

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRail.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/component/rail/NavigationRail.kt
@@ -4,16 +4,15 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.Camera
+import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.ChevronsRight
 import com.composables.icons.lucide.File
-import com.composables.icons.lucide.FileText
-import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Settings
+import com.composables.icons.lucide.Camera
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.screen.main.state.MainCategory
 
@@ -21,9 +20,8 @@ import jp.kaleidot725.adbpad.ui.screen.main.state.MainCategory
 fun NavigationRail(
     category: MainCategory,
     onSelectCategory: (MainCategory) -> Unit,
-    onOpenSetting: () -> Unit,
 ) {
-    Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(modifier = Modifier.fillMaxHeight().padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         NavigationRailItem(
             label = Language.tooltipCommand,
             icon = Lucide.ChevronsRight,
@@ -34,7 +32,7 @@ fun NavigationRail(
 
         NavigationRailItem(
             label = Language.tooltipText,
-            icon = Lucide.FileText,
+            icon = Lucide.File,
             contentDescription = "text menu",
             isSelected = category == MainCategory.Text,
             onClick = { onSelectCategory(MainCategory.Text) },
@@ -57,21 +55,11 @@ fun NavigationRail(
                 onClick = { onSelectCategory(MainCategory.File) },
             )
         }
-
-        Spacer(Modifier.weight(1.0f))
-
-        NavigationRailItem(
-            label = Language.tooltipSetting,
-            icon = Lucide.Settings,
-            contentDescription = "device menu",
-            isSelected = false,
-            onClick = onOpenSetting,
-        )
     }
 }
 
 @Preview
 @Composable
 private fun NavigationRail_Preview() {
-    NavigationRail(MainCategory.Text, {}, {})
+    NavigationRail(MainCategory.Text, {})
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/component/CommandTab.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.Diamond
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Diamond
 import com.composables.icons.lucide.View
 import com.composables.icons.lucide.Wifi
 import jp.kaleidot725.adbpad.domain.model.command.NormalCommandCategory

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainScreen.kt
@@ -44,6 +44,8 @@ import jp.kaleidot725.adbpad.ui.screen.setting.SettingStateHolder
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingSideEffect
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandScreen
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandStateHolder
+import jp.kaleidot725.adbpad.ui.section.right.RightSection
+import jp.kaleidot725.adbpad.ui.section.right.RightStateHolder
 import jp.kaleidot725.adbpad.ui.section.top.TopSection
 import jp.kaleidot725.adbpad.ui.section.top.TopStateHolder
 import org.jetbrains.compose.splitpane.ExperimentalSplitPaneApi
@@ -211,6 +213,7 @@ fun MainScreen(
                 textCommandStateHolder = mainStateHolder.textCommandStateHolder,
                 screenshotStateHolder = mainStateHolder.screenshotStateHolder,
                 topStateHolder = mainStateHolder.topStateHolder,
+                rightStateHolder = mainStateHolder.rightStateHolder,
                 deviceSettingsStateHolder = mainStateHolder.deviceSettingsStateHolder,
                 settingStateHolder = mainStateHolder.settingStateHolder,
             )
@@ -228,6 +231,7 @@ private fun App(
     textCommandStateHolder: TextCommandStateHolder,
     screenshotStateHolder: ScreenshotStateHolder,
     topStateHolder: TopStateHolder,
+    rightStateHolder: RightStateHolder,
     deviceSettingsStateHolder: DeviceSettingsStateHolder,
     settingStateHolder: SettingStateHolder,
 ) {
@@ -241,7 +245,6 @@ private fun App(
                     NavigationRail(
                         category = state.category,
                         onSelectCategory = { onMainAction(MainAction.ClickCategory(it)) },
-                        onOpenSetting = { onMainAction(MainAction.OpenSetting) },
                     )
                 },
                 top = {
@@ -253,6 +256,7 @@ private fun App(
                                 onAction = onAction,
                                 onMainRefresh = onMainRefresh,
                                 onMainOpenDeviceSettings = { device -> onMainAction(MainAction.OpenDeviceSettings(device)) },
+                                onMainOpenSetting = { onMainAction(MainAction.OpenSetting) },
                             )
                         },
                     )
@@ -301,6 +305,17 @@ private fun App(
                             Text("TEST")
                         }
                     }
+                },
+                right = {
+                    MVIChildContent(
+                        mvi = rightStateHolder,
+                        content = { state, onAction ->
+                            RightSection(
+                                state = state,
+                                onAction = onAction,
+                            )
+                        },
+                    )
                 },
                 dialog = {
                     when (state.dialog) {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainScreen.kt
@@ -257,6 +257,7 @@ private fun App(
                                 onMainRefresh = onMainRefresh,
                                 onMainOpenDeviceSettings = { device -> onMainAction(MainAction.OpenDeviceSettings(device)) },
                                 onMainOpenSetting = { onMainAction(MainAction.OpenSetting) },
+                                onLaunchScrcpy = { rightStateHolder.onAction(jp.kaleidot725.adbpad.ui.section.right.state.RightAction.LaunchScrcpy) },
                             )
                         },
                     )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainStateHolder.kt
@@ -25,6 +25,7 @@ import jp.kaleidot725.adbpad.ui.screen.main.state.MainState
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotStateHolder
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingStateHolder
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandStateHolder
+import jp.kaleidot725.adbpad.ui.section.right.RightStateHolder
 import jp.kaleidot725.adbpad.ui.section.top.TopStateHolder
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
@@ -35,6 +36,7 @@ class MainStateHolder(
     val textCommandStateHolder: TextCommandStateHolder,
     val screenshotStateHolder: ScreenshotStateHolder,
     val topStateHolder: TopStateHolder,
+    val rightStateHolder: RightStateHolder,
     val deviceSettingsStateHolder: DeviceSettingsStateHolder,
     val settingStateHolder: SettingStateHolder,
     private val getWindowSizeUseCase: GetWindowSizeUseCase,
@@ -52,6 +54,7 @@ class MainStateHolder(
             textCommandStateHolder,
             screenshotStateHolder,
             topStateHolder,
+            rightStateHolder,
         )
 
     override fun onSetup() {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
@@ -18,8 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.FolderOpen
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.FolderOpen
 
 @Composable
 fun ScreenshotActions(

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotButton.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotButton.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.ChevronDown
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
 

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
@@ -23,8 +23,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Check
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 
@@ -58,8 +58,7 @@ fun ScreenshotDropDownButton(
                     .background(
                         color = UserColor.getDropdownBackgroundColor(),
                         shape = RoundedCornerShape(4.dp),
-                    )
-                    .border(
+                    ).border(
                         width = 1.dp,
                         color = UserColor.getSplitterColor(),
                         shape = RoundedCornerShape(4.dp),

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/AccentColorDropButton.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/AccentColorDropButton.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.ChevronDown
 import jp.kaleidot725.adbpad.domain.model.setting.AccentColor
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/LanguageDropButton.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/component/LanguageDropButton.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.ChevronDown
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandActions.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandActions.kt
@@ -25,8 +25,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Check
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.dummy.TextCommandDummy
@@ -69,8 +69,7 @@ fun TextCommandActions(
                         .background(
                             color = MaterialTheme.colorScheme.surface,
                             shape = RoundedCornerShape(4.dp),
-                        )
-                        .border(
+                        ).border(
                             width = 1.dp,
                             color = UserColor.getSplitterColor(),
                             shape = RoundedCornerShape(4.dp),

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandButton.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandButton.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.ChevronDown
 import jp.kaleidot725.adbpad.domain.model.command.TextCommand
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/RightSection.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/RightSection.kt
@@ -30,14 +30,8 @@ import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.Circle
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Power
-import com.composables.icons.lucide.ScreenShare
-import com.composables.icons.lucide.Speaker
 import com.composables.icons.lucide.Square
 import com.composables.icons.lucide.Triangle
-import com.composables.icons.lucide.Volume
-import com.composables.icons.lucide.Volume1
-import com.composables.icons.lucide.Volume2
-import com.composables.icons.lucide.VolumeX
 import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.device.DeviceState
@@ -56,7 +50,6 @@ fun RightSection(
     RightSection(
         selectedDevice = state.selectedDevice,
         onExecuteCommand = { onAction(RightAction.ExecuteCommand(it)) },
-        onLaunchScrcpy = { onAction(RightAction.LaunchScrcpy) },
     )
 }
 
@@ -65,7 +58,6 @@ fun RightSection(
 private fun RightSection(
     selectedDevice: Device?,
     onExecuteCommand: (DeviceControlCommand) -> Unit,
-    onLaunchScrcpy: () -> Unit,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.background,
@@ -155,16 +147,6 @@ private fun RightSection(
                     )
                 }
 
-                CommandTooltip(
-                    text = Language.tooltipScrcpy,
-                ) {
-                    CommandIconButton(
-                        modifier = Modifier.wrapContentSize(),
-                        image = Lucide.ScreenShare,
-                        onClick = { onLaunchScrcpy() },
-                        padding = 2.dp,
-                    )
-                }
             }
         }
     }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/RightSection.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/RightSection.kt
@@ -1,0 +1,215 @@
+package jp.kaleidot725.adbpad.ui.section.right
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeDown
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.Circle
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Power
+import com.composables.icons.lucide.ScreenShare
+import com.composables.icons.lucide.Speaker
+import com.composables.icons.lucide.Square
+import com.composables.icons.lucide.Triangle
+import com.composables.icons.lucide.Volume
+import com.composables.icons.lucide.Volume1
+import com.composables.icons.lucide.Volume2
+import com.composables.icons.lucide.VolumeX
+import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
+import jp.kaleidot725.adbpad.domain.model.device.Device
+import jp.kaleidot725.adbpad.domain.model.device.DeviceState
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
+import jp.kaleidot725.adbpad.ui.component.button.CommandIconButton
+import jp.kaleidot725.adbpad.ui.component.divider.CommandIconDivider
+import jp.kaleidot725.adbpad.ui.section.right.state.RightAction
+import jp.kaleidot725.adbpad.ui.section.right.state.RightState
+
+@Composable
+fun RightSection(
+    state: RightState,
+    onAction: (RightAction) -> Unit,
+) {
+    RightSection(
+        selectedDevice = state.selectedDevice,
+        onExecuteCommand = { onAction(RightAction.ExecuteCommand(it)) },
+        onLaunchScrcpy = { onAction(RightAction.LaunchScrcpy) },
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun RightSection(
+    selectedDevice: Device?,
+    onExecuteCommand: (DeviceControlCommand) -> Unit,
+    onLaunchScrcpy: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxHeight().width(50.dp),
+    ) {
+        if (selectedDevice != null) {
+            Column(
+                modifier = Modifier.fillMaxHeight().padding(vertical = 8.dp, horizontal = 2.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                CommandTooltip(
+                    text = Language.tooltipPower,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Lucide.Power,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Power) },
+                        padding = 2.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipVolumeUp,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Icons.AutoMirrored.Filled.VolumeUp,
+                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeUp) },
+                        padding = 0.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipVolumeDown,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Icons.AutoMirrored.Filled.VolumeDown,
+                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeDown) },
+                        padding = 0.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipVolumeMute,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Icons.AutoMirrored.Filled.VolumeOff,
+                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeMute) },
+                        padding = 0.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipBack,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Lucide.Triangle,
+                        degrees = -90f,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Back) },
+                        padding = 2.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipHome,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Lucide.Circle,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Home) },
+                        padding = 2.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipRecents,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Lucide.Square,
+                        onClick = { onExecuteCommand(DeviceControlCommand.Recents) },
+                        padding = 2.dp,
+                    )
+                }
+
+                CommandTooltip(
+                    text = Language.tooltipScrcpy,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.wrapContentSize(),
+                        image = Lucide.ScreenShare,
+                        onClick = { onLaunchScrcpy() },
+                        padding = 2.dp,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CommandTooltip(
+    text: String,
+    tooltipPlacement: TooltipPlacement =
+        TooltipPlacement.ComponentRect(
+            anchor = Alignment.TopCenter,
+            alignment = Alignment.BottomCenter,
+            offset = DpOffset(0.dp, 30.dp),
+        ),
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    TooltipArea(
+        delayMillis = 300,
+        tooltip = {
+            Card(
+                modifier = Modifier.border(1.dp, UserColor.getSplitterColor()),
+            ) {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
+                )
+            }
+        },
+        tooltipPlacement = tooltipPlacement,
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    RightSection(
+        state =
+            RightState(
+                selectedDevice = Device(serial = "test", name = "Test Device", state = DeviceState.DEVICE),
+            ),
+        onAction = {},
+    )
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/RightStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/RightStateHolder.kt
@@ -1,0 +1,78 @@
+package jp.kaleidot725.adbpad.ui.section.right
+
+import jp.kaleidot725.adbpad.core.mvi.MVIBase
+import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
+import jp.kaleidot725.adbpad.domain.model.device.Device
+import jp.kaleidot725.adbpad.domain.usecase.command.ExecuteDeviceControlCommandUseCase
+import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
+import jp.kaleidot725.adbpad.domain.usecase.scrcpy.LaunchScrcpyUseCase
+import jp.kaleidot725.adbpad.ui.section.right.state.RightAction
+import jp.kaleidot725.adbpad.ui.section.right.state.RightSideEffect
+import jp.kaleidot725.adbpad.ui.section.right.state.RightState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+class RightStateHolder(
+    private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
+    private val executeDeviceControlCommandUseCase: ExecuteDeviceControlCommandUseCase,
+    private val launchScrcpyUseCase: LaunchScrcpyUseCase,
+) : MVIBase<RightState, RightAction, RightSideEffect>(RightState()) {
+    private var selectedDeviceJob: Job? = null
+
+    override fun onSetup() {
+        collectSelectedDevice()
+    }
+
+    override fun onRefresh() {
+        collectSelectedDevice()
+    }
+
+    override fun onAction(uiAction: RightAction) {
+        coroutineScope.launch {
+            when (uiAction) {
+                is RightAction.ExecuteCommand -> executeCommand(uiAction.command)
+                RightAction.LaunchScrcpy -> launchScrcpy()
+                RightAction.ShowScrcpyControl -> showScrcpyControl()
+                RightAction.HideScrcpyControl -> hideScrcpyControl()
+            }
+        }
+    }
+
+    private suspend fun executeCommand(command: DeviceControlCommand) {
+        val device = currentState.selectedDevice ?: return
+        executeDeviceControlCommandUseCase(
+            device = device,
+            command = command,
+        )
+    }
+
+    private suspend fun launchScrcpy() {
+        val device = currentState.selectedDevice ?: return
+        try {
+            val success = launchScrcpyUseCase(device)
+            if (success) {
+                showScrcpyControl()
+            }
+        } catch (e: Exception) {
+            println("Failed to launch Scrcpy: ${e.message}")
+        }
+    }
+
+    private fun showScrcpyControl() {
+        update { copy(isScrcpyControlVisible = true) }
+    }
+
+    private fun hideScrcpyControl() {
+        update { copy(isScrcpyControlVisible = false) }
+    }
+
+    private fun collectSelectedDevice() {
+        selectedDeviceJob?.cancel()
+        selectedDeviceJob =
+            coroutineScope.launch {
+                getSelectedDeviceFlowUseCase().collect { device ->
+                    update { copy(selectedDevice = device) }
+                }
+            }
+    }
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/state/RightAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/state/RightAction.kt
@@ -1,0 +1,16 @@
+package jp.kaleidot725.adbpad.ui.section.right.state
+
+import jp.kaleidot725.adbpad.core.mvi.MVIAction
+import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
+
+sealed class RightAction : MVIAction {
+    data class ExecuteCommand(
+        val command: DeviceControlCommand,
+    ) : RightAction()
+
+    data object LaunchScrcpy : RightAction()
+
+    data object ShowScrcpyControl : RightAction()
+
+    data object HideScrcpyControl : RightAction()
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/state/RightSideEffect.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/state/RightSideEffect.kt
@@ -1,0 +1,5 @@
+package jp.kaleidot725.adbpad.ui.section.right.state
+
+import jp.kaleidot725.adbpad.core.mvi.MVISideEffect
+
+sealed class RightSideEffect : MVISideEffect

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/state/RightState.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/right/state/RightState.kt
@@ -1,0 +1,9 @@
+package jp.kaleidot725.adbpad.ui.section.right.state
+
+import jp.kaleidot725.adbpad.core.mvi.MVIState
+import jp.kaleidot725.adbpad.domain.model.device.Device
+
+data class RightState(
+    val selectedDevice: Device? = null,
+    val isScrcpyControlVisible: Boolean = false,
+) : MVIState

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.ScreenShare
 import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Settings2
 import jp.kaleidot725.adbpad.domain.model.device.Device
@@ -41,6 +42,7 @@ fun TopSection(
     onMainRefresh: () -> Unit,
     onMainOpenDeviceSettings: (Device) -> Unit,
     onMainOpenSetting: () -> Unit,
+    onLaunchScrcpy: () -> Unit,
 ) {
     TopSection(
         state = state,
@@ -48,6 +50,7 @@ fun TopSection(
         onRefresh = onMainRefresh,
         onOpenDeviceSettings = onMainOpenDeviceSettings,
         onOpenSetting = onMainOpenSetting,
+        onLaunchScrcpy = onLaunchScrcpy,
     )
 }
 
@@ -59,6 +62,7 @@ private fun TopSection(
     onOpenDeviceSettings: (Device) -> Unit,
     onRefresh: () -> Unit,
     onOpenSetting: () -> Unit,
+    onLaunchScrcpy: () -> Unit,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.background,
@@ -78,6 +82,17 @@ private fun TopSection(
             )
 
             if (state.selectedDevice != null) {
+                CommandTooltip(
+                    text = Language.tooltipScrcpy,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.padding(vertical = 4.dp).padding(start = 8.dp),
+                        image = Lucide.ScreenShare,
+                        onClick = { onLaunchScrcpy() },
+                        padding = 2.dp,
+                    )
+                }
+
                 CommandTooltip(
                     text = Language.tooltipSetting,
                 ) {
@@ -147,5 +162,6 @@ private fun Preview() {
         onRefresh = {},
         onOpenDeviceSettings = {},
         onOpenSetting = {},
+        onLaunchScrcpy = {},
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -22,22 +23,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.Circle
 import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Power
-import com.composables.icons.lucide.ScreenShare
+import com.composables.icons.lucide.Settings
 import com.composables.icons.lucide.Settings2
-import com.composables.icons.lucide.Square
-import com.composables.icons.lucide.Triangle
-import com.composables.icons.lucide.Volume1
-import com.composables.icons.lucide.Volume2
-import com.composables.icons.lucide.VolumeX
-import jp.kaleidot725.adbpad.domain.model.command.DeviceControlCommand
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.button.CommandIconButton
-import jp.kaleidot725.adbpad.ui.component.divider.CommandIconDivider
 import jp.kaleidot725.adbpad.ui.section.top.component.DropDownDeviceMenu
 import jp.kaleidot725.adbpad.ui.section.top.state.TopAction
 import jp.kaleidot725.adbpad.ui.section.top.state.TopState
@@ -48,14 +40,14 @@ fun TopSection(
     onAction: (TopAction) -> Unit,
     onMainRefresh: () -> Unit,
     onMainOpenDeviceSettings: (Device) -> Unit,
+    onMainOpenSetting: () -> Unit,
 ) {
     TopSection(
         state = state,
-        onExecuteCommand = { onAction(TopAction.ExecuteCommand(it)) },
         onSelectDevice = { onAction(TopAction.SelectDevice(it)) },
-        onLaunchScrcpy = { onAction(TopAction.LaunchScrcpy) },
         onRefresh = onMainRefresh,
         onOpenDeviceSettings = onMainOpenDeviceSettings,
+        onOpenSetting = onMainOpenSetting,
     )
 }
 
@@ -63,126 +55,52 @@ fun TopSection(
 @Composable
 private fun TopSection(
     state: TopState,
-    onExecuteCommand: (DeviceControlCommand) -> Unit,
     onSelectDevice: (Device) -> Unit,
-    onLaunchScrcpy: () -> Unit,
     onOpenDeviceSettings: (Device) -> Unit,
     onRefresh: () -> Unit,
+    onOpenSetting: () -> Unit,
 ) {
     Surface(
         color = MaterialTheme.colorScheme.background,
         modifier = Modifier.fillMaxWidth().height(40.dp),
     ) {
-        Box {
-            Row(Modifier.align(Alignment.CenterStart).wrapContentSize().padding(start = 12.dp)) {
-                DropDownDeviceMenu(
-                    devices = state.devices,
-                    selectedDevice = state.selectedDevice,
-                    onSelectDevice = onSelectDevice,
-                    onOpenDeviceSettings = onOpenDeviceSettings,
-                    onRefresh = onRefresh,
-                    modifier = Modifier.wrapContentWidth().align(Alignment.CenterVertically),
-                )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DropDownDeviceMenu(
+                devices = state.devices,
+                selectedDevice = state.selectedDevice,
+                onSelectDevice = onSelectDevice,
+                onOpenDeviceSettings = onOpenDeviceSettings,
+                onRefresh = onRefresh,
+                modifier = Modifier.wrapContentWidth(),
+            )
 
-                if (state.selectedDevice != null) {
-                    CommandTooltip(
-                        text = Language.tooltipSetting,
-                    ) {
-                        CommandIconButton(
-                            modifier = Modifier.padding(vertical = 4.dp),
-                            image = Lucide.Settings2,
-                            onClick = { onOpenDeviceSettings(state.selectedDevice) },
-                            padding = 2.dp,
-                        )
-                    }
+            if (state.selectedDevice != null) {
+                CommandTooltip(
+                    text = Language.tooltipSetting,
+                ) {
+                    CommandIconButton(
+                        modifier = Modifier.padding(vertical = 4.dp).padding(start = 8.dp),
+                        image = Lucide.Settings2,
+                        onClick = { onOpenDeviceSettings(state.selectedDevice) },
+                        padding = 2.dp,
+                    )
                 }
             }
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                modifier = Modifier.align(Alignment.CenterEnd).wrapContentSize().padding(4.dp),
+            Spacer(modifier = Modifier.weight(1f))
+
+            CommandTooltip(
+                text = Language.tooltipSetting,
             ) {
-                CommandTooltip(
-                    text = Language.tooltipPower,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.Power,
-                        onClick = { onExecuteCommand(DeviceControlCommand.Power) },
-                        padding = 2.dp,
-                    )
-                }
-
-                CommandTooltip(
-                    text = Language.tooltipVolumeUp,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.Volume2,
-                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeUp) },
-                    )
-                }
-
-                CommandTooltip(
-                    text = Language.tooltipVolumeDown,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.Volume1,
-                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeDown) },
-                    )
-                }
-
-                CommandTooltip(
-                    text = Language.tooltipVolumeMute,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.VolumeX,
-                        onClick = { onExecuteCommand(DeviceControlCommand.VolumeMute) },
-                    )
-                }
-
-                CommandIconDivider()
-
-                CommandTooltip(
-                    text = Language.tooltipBack,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.Triangle,
-                        degrees = -90f,
-                        onClick = { onExecuteCommand(DeviceControlCommand.Back) },
-                        padding = 2.dp,
-                    )
-                }
-
-                CommandTooltip(
-                    text = Language.tooltipHome,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.Circle,
-                        onClick = { onExecuteCommand(DeviceControlCommand.Home) },
-                        padding = 2.dp,
-                    )
-                }
-
-                CommandTooltip(
-                    text = Language.tooltipRecents,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.Square,
-                        onClick = { onExecuteCommand(DeviceControlCommand.Recents) },
-                        padding = 2.dp,
-                    )
-                }
-
-                CommandIconDivider()
-
-                CommandTooltip(
-                    text = Language.tooltipScrcpy,
-                ) {
-                    CommandIconButton(
-                        image = Lucide.ScreenShare,
-                        onClick = { onLaunchScrcpy() },
-                        padding = 2.dp,
-                    )
-                }
+                CommandIconButton(
+                    modifier = Modifier.padding(vertical = 4.dp),
+                    image = Lucide.Settings,
+                    onClick = onOpenSetting,
+                    padding = 2.dp,
+                )
             }
         }
     }
@@ -225,10 +143,9 @@ private fun CommandTooltip(
 private fun Preview() {
     TopSection(
         state = TopState(),
-        onExecuteCommand = {},
         onSelectDevice = {},
-        onLaunchScrcpy = {},
         onRefresh = {},
         onOpenDeviceSettings = {},
+        onOpenSetting = {},
     )
 }


### PR DESCRIPTION
## Summary
- Move scrcpy mirroring button from RightSection to TopSection for better accessibility
- Position scrcpy button next to device dropdown for improved UX
- Clean up RightSection layout and remove unnecessary scrcpy button
- Improve overall UI consistency and usability

## Changes Made
- **TopSection**: Added scrcpy button next to device dropdown
- **RightSection**: Removed scrcpy button and cleaned up layout
- **MainScreen**: Updated TopSection integration to support scrcpy functionality
- **UI Layout**: Improved button positioning and spacing

## Test plan
- [x] Verify scrcpy button appears in TopSection when device is selected
- [x] Verify scrcpy button is removed from RightSection
- [x] Test scrcpy functionality works from new location
- [x] Verify UI layout and spacing is consistent
- [x] Test with and without selected device

🤖 Generated with [Claude Code](https://claude.ai/code)