### PR TITLE
feat: align screenshot controls with material spec

### DIFF
--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
@@ -60,6 +60,9 @@ fun ScreenshotScreen(
         onOpenDirectory = {
             onAction(ScreenshotAction.OpenDirectory)
         },
+        onEditScreenshot = {
+            onAction(ScreenshotAction.EditScreenshot)
+        },
         onCopyScreenshot = {
             onAction(ScreenshotAction.CopyScreenshotToClipboard)
         },
@@ -106,6 +109,7 @@ private fun ScreenshotScreen(
     searchText: String,
     sortType: SortType,
     onOpenDirectory: () -> Unit,
+    onEditScreenshot: () -> Unit,
     onCopyScreenshot: () -> Unit,
     onDeleteScreenshot: () -> Unit,
     onDeleteSpecificScreenshot: (Screenshot) -> Unit,
@@ -178,6 +182,7 @@ private fun ScreenshotScreen(
                         screenshot = screenshot,
                         isCapturing = isCapturing,
                         onOpenDirectory = onOpenDirectory,
+                        onEditScreenshot = onEditScreenshot,
                         onCopyScreenshot = onCopyScreenshot,
                         modifier =
                             Modifier
@@ -227,6 +232,7 @@ private fun ScreenshotScreen_Preview() {
         searchText = "",
         sortType = SortType.SORT_BY_NAME_ASC,
         onOpenDirectory = {},
+        onEditScreenshot = {},
         onCopyScreenshot = {},
         onDeleteScreenshot = {},
         onDeleteSpecificScreenshot = {},

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -129,25 +129,45 @@ private fun ScreenshotScreen(
                     .weight(1.0f),
         ) {
             first(minSize = 350.dp) {
-                Column {
-                    ScreenshotHeader(
-                        searchText = searchText,
-                        sortType = sortType,
-                        onUpdateSortType = onUpdateSortType,
-                        onUpdateSearchText = onUpdateSearchText,
-                        modifier = Modifier,
-                    )
-
-                    Divider(modifier = Modifier.height(1.dp).fillMaxWidth().defaultBorder())
-
-                    ScreenshotExplorer(
-                        selectedScreenshot = screenshot,
-                        screenshots = screenshots,
-                        onSelectScreenShot = onSelectScreenshot,
-                        onDeleteScreenshot = onDeleteSpecificScreenshot,
-                        onNextScreenshot = onNextScreenshot,
-                        onPreviousScreenshot = onPreviousScreenshot,
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Column(
                         modifier = Modifier.fillMaxSize(),
+                    ) {
+                        ScreenshotHeader(
+                            searchText = searchText,
+                            sortType = sortType,
+                            onUpdateSortType = onUpdateSortType,
+                            onUpdateSearchText = onUpdateSearchText,
+                            modifier = Modifier,
+                        )
+
+                        Divider(modifier = Modifier.height(1.dp).fillMaxWidth().defaultBorder())
+
+                        ScreenshotExplorer(
+                            selectedScreenshot = screenshot,
+                            screenshots = screenshots,
+                            onSelectScreenShot = onSelectScreenshot,
+                            onDeleteScreenshot = onDeleteSpecificScreenshot,
+                            onNextScreenshot = onNextScreenshot,
+                            onPreviousScreenshot = onPreviousScreenshot,
+                            modifier =
+                                Modifier
+                                    .weight(1.0f)
+                                    .fillMaxWidth(),
+                        )
+                    }
+
+                    ScreenshotMenu(
+                        selectedCommand = selectCommand,
+                        onSelectCommand = onSelectCommand,
+                        commands = commands,
+                        canCapture = canCapture,
+                        isCapturing = isCapturing,
+                        onTakeScreenshot = onTakeScreenshot,
+                        modifier =
+                            Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(16.dp),
                     )
                 }
             }
@@ -163,16 +183,6 @@ private fun ScreenshotScreen(
                             Modifier
                                 .weight(1.0f)
                                 .fillMaxHeight(),
-                    )
-
-                    ScreenshotMenu(
-                        selectedCommand = selectCommand,
-                        onSelectCommand = onSelectCommand,
-                        commands = commands,
-                        canCapture = canCapture,
-                        isCapturing = isCapturing,
-                        onTakeScreenshot = onTakeScreenshot,
-                        modifier = Modifier.wrapContentSize().align(Alignment.End),
                     )
                 }
             }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
@@ -67,6 +67,7 @@ class ScreenshotStateHolder(
                 ScreenshotAction.OpenDirectory -> openDirectory()
                 ScreenshotAction.CopyScreenshotToClipboard -> copyScreenShotToClipboard()
                 ScreenshotAction.DeleteScreenshotToClipboard -> deleteScreenShotToClipboard()
+                ScreenshotAction.EditScreenshot -> editScreenshot()
                 is ScreenshotAction.DeleteScreenshot -> deleteSpecificScreenshot(uiAction.screenshot)
                 is ScreenshotAction.SelectScreenshot -> selectScreenshot(uiAction.screenshot)
                 ScreenshotAction.NextScreenshot -> nextScreenshot()
@@ -156,6 +157,15 @@ class ScreenshotStateHolder(
     private suspend fun deleteScreenShotToClipboard() {
         screenshotCommandRepository.delete(currentState.preview)
         initPreviews()
+    }
+
+    private suspend fun editScreenshot() {
+        val file = currentState.preview.file ?: return
+        val desktop = Desktop.getDesktop()
+        when {
+            desktop.isSupported(Desktop.Action.EDIT) -> desktop.edit(file)
+            desktop.isSupported(Desktop.Action.OPEN) -> desktop.open(file)
+        }
     }
 
     private suspend fun deleteSpecificScreenshot(screenshot: Screenshot) {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotActions.kt
@@ -17,36 +17,66 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import com.composables.icons.lucide.FolderOpen
+import com.composables.icons.lucide.Copy
+import com.composables.icons.lucide.Folder
+import com.composables.icons.lucide.ImageUp
 import com.composables.icons.lucide.Lucide
 
 @Composable
 fun ScreenshotActions(
     enabled: Boolean,
     onOpen: () -> Unit,
+    onEdit: () -> Unit,
+    onCopy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
     ) {
-        IconButton(
+        ActionIcon(
             onClick = onOpen,
             enabled = enabled,
-            modifier =
-                Modifier
-                    .padding(vertical = 4.dp)
-                    .size(32.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .align(Alignment.CenterVertically),
-        ) {
-            Icon(
-                imageVector = Lucide.FolderOpen,
-                contentDescription = "copy",
-                modifier = Modifier.height(20.dp),
-            )
-        }
+            image = Lucide.Folder,
+        )
+
+        ActionIcon(
+            onClick = onEdit,
+            enabled = enabled,
+            image = Lucide.ImageUp,
+        )
+
+        ActionIcon(
+            onClick = onCopy,
+            enabled = enabled,
+            image = Lucide.Copy,
+        )
+    }
+}
+
+@Composable
+private fun ActionIcon(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    image: ImageVector,
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier =
+            Modifier
+                .padding(vertical = 4.dp)
+                .size(32.dp)
+                .clip(RoundedCornerShape(8.dp)),
+    ) {
+        Icon(
+            imageVector = image,
+            contentDescription = null,
+            modifier = Modifier.height(20.dp),
+        )
     }
 }
 
@@ -56,6 +86,8 @@ private fun ScreenshotHeader_Preview() {
     ScreenshotActions(
         enabled = true,
         onOpen = {},
+        onEdit = {},
+        onCopy = {},
         modifier =
             Modifier
                 .fillMaxWidth()

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotDropDownButton.kt
@@ -5,24 +5,30 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupProperties
+import com.composables.icons.lucide.Camera
 import com.composables.icons.lucide.Check
 import com.composables.icons.lucide.Lucide
 import jp.kaleidot725.adbpad.domain.model.command.ScreenshotCommand
@@ -40,29 +46,57 @@ fun ScreenshotDropDownButton(
 ) {
     var expanded by remember { mutableStateOf(false) }
 
-    Box(modifier) {
-        ScreenshotButton(
-            selectedCommand = selectedCommand,
-            canCapture = canCapture,
-            isCapturing = isCapturing,
-            onTake = { onTakeScreenshot(selectedCommand) },
-            onChangeType = { expanded = true },
-        )
+    LaunchedEffect(canCapture) {
+        if (!canCapture) {
+            expanded = false
+        }
+    }
+
+    LaunchedEffect(isCapturing) {
+        if (isCapturing) {
+            expanded = false
+        }
+    }
+
+    val hasCommands = commands.isNotEmpty()
+    val buttonEnabled = canCapture && hasCommands
+    val canOpenMenu = buttonEnabled && !isCapturing
+
+    Box(modifier = modifier.wrapContentSize()) {
+        FloatingActionButton(
+            onClick = { if (canOpenMenu) expanded = true },
+            modifier = Modifier.align(Alignment.Center).alpha(if (buttonEnabled) 1f else 0.38f),
+        ) {
+            if (isCapturing) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Icon(
+                    imageVector = Lucide.Camera,
+                    contentDescription = "capture screenshot",
+                )
+            }
+        }
 
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
             modifier =
                 Modifier
+                    .align(Alignment.TopEnd)
                     .width(250.dp)
                     .background(
                         color = UserColor.getDropdownBackgroundColor(),
-                        shape = RoundedCornerShape(4.dp),
+                        shape = MaterialTheme.shapes.extraSmall,
                     ).border(
                         width = 1.dp,
                         color = UserColor.getSplitterColor(),
-                        shape = RoundedCornerShape(4.dp),
+                        shape = MaterialTheme.shapes.extraSmall,
                     ),
+            offset = DpOffset(x = (-12).dp, y = (-4).dp),
+            properties = PopupProperties(focusable = true),
         ) {
             commands.forEach { command ->
                 DropdownMenuItem(
@@ -79,7 +113,7 @@ fun ScreenshotDropDownButton(
                                     Icon(
                                         imageVector = Lucide.Check,
                                         contentDescription = "",
-                                        modifier = Modifier.fillMaxSize(),
+                                        modifier = Modifier.align(Alignment.Center),
                                     )
                                 }
                             }
@@ -93,6 +127,7 @@ fun ScreenshotDropDownButton(
                     },
                     onClick = {
                         onSelectCommand(command)
+                        onTakeScreenshot(command)
                         expanded = false
                     },
                 )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/component/ScreenshotViewer.kt
@@ -42,6 +42,7 @@ fun ScreenshotViewer(
     screenshot: Screenshot,
     isCapturing: Boolean,
     onOpenDirectory: () -> Unit,
+    onEditScreenshot: () -> Unit,
     onCopyScreenshot: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -49,6 +50,8 @@ fun ScreenshotViewer(
         ScreenshotActions(
             enabled = screenshot.file != null,
             onOpen = onOpenDirectory,
+            onEdit = onEditScreenshot,
+            onCopy = onCopyScreenshot,
             modifier = Modifier.height(48.dp).padding(horizontal = 12.dp).align(Alignment.End),
         )
 
@@ -164,6 +167,7 @@ private fun ScreenshotViewer_Preview() {
         screenshot = Screenshot(null),
         isCapturing = false,
         onOpenDirectory = {},
+        onEditScreenshot = {},
         onCopyScreenshot = {},
         modifier = Modifier.fillMaxSize(),
     )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/state/ScreenshotAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/state/ScreenshotAction.kt
@@ -28,6 +28,8 @@ sealed class ScreenshotAction : MVIAction {
 
     data object DeleteScreenshotToClipboard : ScreenshotAction()
 
+    data object EditScreenshot : ScreenshotAction()
+
     data class DeleteScreenshot(
         val screenshot: Screenshot,
     ) : ScreenshotAction()

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandList.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandList.kt
@@ -13,11 +13,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -107,9 +105,6 @@ fun TextCommandList(
 
         FloatingActionButton(
             onClick = onAddNewTextCommand,
-            shape = CircleShape,
-            containerColor = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
             modifier =
                 Modifier
                     .align(Alignment.BottomEnd)


### PR DESCRIPTION
## Summary
- Switch the text command FAB and screenshot capture FABs to Material 3 defaults, relocating the capture button to the left pane.
- Surface open/edit/copy screenshot actions alongside the preview header and wire the new edit flow through ScreenshotAction/ScreenshotStateHolder.
- Harden clipboard handling by synchronizing with the AWT event thread and retrying on transient failures so release builds keep a working copy-to-clipboard feature.

## Testing
- ./gradlew ktlintCheck
- ./gradlew test
- Manual: verify screenshot capture dropdown, preview edit button (opens Preview), and copy-to-clipboard still function.
