### PR TITLE
Fix text field state sync after screen refresh

### DIFF
--- a/core/view/main/kotlin/jp/kaleidot725/adbpad/ui/component/text/DefaultOutlineTextField.kt
+++ b/core/view/main/kotlin/jp/kaleidot725/adbpad/ui/component/text/DefaultOutlineTextField.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,6 +25,10 @@ fun DefaultOutlineTextField(
     modifier: Modifier = Modifier,
 ) {
     var localText by remember(id) { mutableStateOf(initialText) }
+    LaunchedEffect(id, initialText) {
+        localText = initialText
+    }
+
     val textStyle = MaterialTheme.typography.bodySmall
     OutlinedTextField(
         label = { Text(label, style = textStyle) },

--- a/core/view/main/kotlin/jp/kaleidot725/adbpad/ui/component/text/DefaultTextField.kt
+++ b/core/view/main/kotlin/jp/kaleidot725/adbpad/ui/component/text/DefaultTextField.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +46,10 @@ fun DefaultTextField(
     modifier: Modifier = Modifier,
 ) {
     var localText by remember(id) { mutableStateOf(initialText) }
+
+    LaunchedEffect(id, initialText) {
+        localText = initialText
+    }
 
     Box(modifier) {
         Row(


### PR DESCRIPTION
## Summary
- Sync `DefaultTextField` and `DefaultOutlineTextField` internal state when `initialText` changes
- Preserve search and input values after menu updates or screen re-creation

## Testing
- `./gradlew compileKotlinJvm` passed
- `./gradlew ktlintCheck` was not fully run to completion because of pre-existing ktlint violations outside the changed files