### PR TITLE
Fix text command editor placeholder visibility

### DIFF
--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -69,6 +69,8 @@ object Language : StringResources {
         get() = getCurrentResources().uninstallApp
     override val textCommandUnTitle: String
         get() = getCurrentResources().textCommandUnTitle
+    override val textCommandTextPlaceholder: String
+        get() = getCurrentResources().textCommandTextPlaceholder
     override val screenshotTakeByCurrentTheme: String
         get() = getCurrentResources().screenshotTakeByCurrentTheme
     override val screenshotTakeByDarkTheme: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -35,6 +35,7 @@ object ChineseResources : StringResources {
     override val uninstallApp: String = "卸载"
 
     override val textCommandUnTitle: String = "取消文本标题命令"
+    override val textCommandTextPlaceholder: String = "输入要发送的文本"
 
     override val screenshotTakeByCurrentTheme = "按当前主题截图"
     override val screenshotTakeByDarkTheme = "按深色主题截图"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -35,6 +35,7 @@ object EnglishResources : StringResources {
     override val uninstallApp: String = "Uninstall"
 
     override val textCommandUnTitle: String = "untitle text command"
+    override val textCommandTextPlaceholder: String = "Enter text to send"
 
     override val screenshotTakeByCurrentTheme = "Take by current theme"
     override val screenshotTakeByDarkTheme = "Take by dark theme"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -35,6 +35,7 @@ object JapaneseResources : StringResources {
     override val uninstallApp: String = "アンインストール"
 
     override val textCommandUnTitle: String = "untitle text command"
+    override val textCommandTextPlaceholder: String = "送信するテキストを入力"
     override val screenshotTakeByCurrentTheme = "現在のテーマで撮影する"
     override val screenshotTakeByDarkTheme = "ダークテーマで撮影する"
     override val screenshotTakeByLightTheme = "ライトテーマで撮影する"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -34,6 +34,7 @@ interface StringResources {
     val uninstallApp: String
 
     val textCommandUnTitle: String
+    val textCommandTextPlaceholder: String
     val screenshotTakeByCurrentTheme: String
     val screenshotTakeByDarkTheme: String
     val screenshotTakeByLightTheme: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -35,6 +35,7 @@ object TurkishResources : StringResources {
     override val uninstallApp: String = "Kaldır"
 
     override val textCommandUnTitle: String = "başlıksız metin komutu"
+    override val textCommandTextPlaceholder: String = "Gönderilecek metni gir"
 
     override val screenshotTakeByCurrentTheme = "Mevcut tema ile al"
     override val screenshotTakeByDarkTheme = "Koyu tema ile al"

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/component/TextCommandEditor.kt
@@ -1,19 +1,23 @@
 package jp.kaleidot725.adbpad.ui.screen.text.component
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -59,6 +63,7 @@ fun TextCommandEditor(
             mutableStateOf(LineBreakTransformation(option, primaryColor))
         }
         var commandText by remember(command.id) { mutableStateOf(command.text) }
+
         BasicTextField(
             value = commandText,
             onValueChange = { textValue ->
@@ -69,7 +74,20 @@ fun TextCommandEditor(
             maxLines = Int.MAX_VALUE,
             textStyle = TextStyle(color = MaterialTheme.colorScheme.onSurface, fontSize = 16.sp),
             cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),
-            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 12.dp),
+            decorationBox = { innerTextField ->
+                Box(modifier = Modifier.fillMaxSize()) {
+                    if (commandText.isEmpty()) {
+                        Text(
+                            text = Language.textCommandTextPlaceholder,
+                            style = MaterialTheme.typography.bodyMedium.copy(fontSize = 16.sp),
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                            modifier = Modifier.align(Alignment.TopStart),
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+            modifier = Modifier.weight(1.0f).fillMaxWidth().padding(vertical = 12.dp, horizontal = 12.dp),
         )
     }
 }


### PR DESCRIPTION
## Summary
- Make the text command body editor occupy the available center pane space
- Show a localized placeholder when the text command body is empty
- Add the placeholder string to all language resources

Closes #250

## Verification
- ./gradlew compileKotlinJvm
- ./gradlew runKtlintCheckOverJvmMainSourceSet