### PR TITLE
Add double-click file previews to app file tree

### DIFF
--- a/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
+++ b/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
@@ -133,15 +133,43 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
             }
         }
 
+    override suspend fun saveAppFile(
+        device: Device,
+        entry: AppFileEntry.File,
+        destination: File,
+    ): Result<Unit, Exception> =
+        withContext(Dispatchers.IO) {
+            try {
+                val target = prepareDestinationFile(destination)
+                if (entry.size == 0L) {
+                    target.outputStream().use { }
+                } else {
+                    pullAppFile(device, entry, target)
+                }
+                Ok(Unit)
+            } catch (exception: Exception) {
+                if (exception is CancellationException) throw exception
+                Err(exception)
+            }
+        }
+
     private suspend fun pullAppFile(
         device: Device,
         entry: AppFileEntry.File,
     ): File {
-        val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
         val localFile = createPreviewFile(entry)
+        pullAppFile(device, entry, localFile)
+        return localFile
+    }
+
+    private suspend fun pullAppFile(
+        device: Device,
+        entry: AppFileEntry.File,
+        localFile: File,
+    ) {
+        val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
         val isPulled = adbClient.execute(PullRequest(entry.path, localFile, supportedFeatures), device.serial)
         if (!isPulled) throw IOException("Failed to load ${entry.name}")
-        return localFile
     }
 
     private fun createPreviewFile(entry: AppFileEntry.File): File {
@@ -150,6 +178,19 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
         return createTempFile(prefix = "adbpad-preview-", suffix = suffix)
             .toFile()
             .apply { deleteOnExit() }
+    }
+
+    private fun prepareDestinationFile(destination: File): File {
+        if (destination.exists() && destination.isDirectory) {
+            throw IOException("${destination.name} is a directory")
+        }
+
+        destination.parentFile?.mkdirs()
+        if (!destination.exists() && !destination.createNewFile()) {
+            throw IOException("Failed to create ${destination.name}")
+        }
+
+        return destination
     }
 
     private fun getRootPath(

--- a/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
+++ b/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
@@ -180,7 +180,7 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
     private fun AndroidFile.toAppFileEntry(): AppFileEntry {
         val path = directory.resolveChildPath(name)
         return when (type) {
-            AndroidFileType.DIRECTORY ->
+            AndroidFileType.DIRECTORY -> {
                 AppFileEntry.Directory(
                     name = name,
                     path = path,
@@ -189,7 +189,9 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
                     date = date,
                     time = time,
                 )
-            AndroidFileType.REGULAR_FILE ->
+            }
+
+            AndroidFileType.REGULAR_FILE -> {
                 AppFileEntry.File(
                     name = name,
                     path = path,
@@ -198,7 +200,9 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
                     date = date,
                     time = time,
                 )
-            AndroidFileType.SYMBOLIC_LINK ->
+            }
+
+            AndroidFileType.SYMBOLIC_LINK -> {
                 AppFileEntry.Link(
                     name = name,
                     path = path,
@@ -207,7 +211,9 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
                     date = date,
                     time = time,
                 )
-            else ->
+            }
+
+            else -> {
                 AppFileEntry.Other(
                     name = name,
                     path = path,
@@ -216,6 +222,7 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
                     date = date,
                     time = time,
                 )
+            }
         }
     }
 

--- a/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
+++ b/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
@@ -10,8 +10,10 @@ import com.malinskiy.adam.request.shell.v1.ShellCommandRequest
 import com.malinskiy.adam.request.sync.AndroidFile
 import com.malinskiy.adam.request.sync.AndroidFileType
 import com.malinskiy.adam.request.sync.ListFilesRequest
+import com.malinskiy.adam.request.sync.PullRequest
 import jp.kaleidot725.adbpad.domain.model.app.AppDataDirectory
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
+import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
 import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.repository.InstalledAppRepository
@@ -19,7 +21,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.IOException
 import java.util.Locale
+import kotlin.io.path.createTempFile
 
 class InstalledAppRepositoryImpl : InstalledAppRepository {
     private val adbClient = AndroidDebugBridgeClientFactory().build()
@@ -108,6 +112,46 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
             }
         }
 
+    override suspend fun getAppFilePreview(
+        device: Device,
+        entry: AppFileEntry,
+    ): Result<AppFilePreview, Exception> =
+        withContext(Dispatchers.IO) {
+            try {
+                if (entry !is AppFileEntry.File) return@withContext Ok(AppFilePreview.Unsupported(entry))
+
+                when {
+                    entry.size == 0L && entry.isTextFile() -> Ok(AppFilePreview.Text(entry, ""))
+                    entry.size == 0L -> Ok(AppFilePreview.Unsupported(entry))
+                    entry.isImageFile() -> Ok(AppFilePreview.Image(entry, pullAppFile(device, entry)))
+                    entry.isTextFile() -> Ok(AppFilePreview.Text(entry, pullAppFile(device, entry).readText()))
+                    else -> Ok(AppFilePreview.Unsupported(entry))
+                }
+            } catch (exception: Exception) {
+                if (exception is CancellationException) throw exception
+                Err(exception)
+            }
+        }
+
+    private suspend fun pullAppFile(
+        device: Device,
+        entry: AppFileEntry.File,
+    ): File {
+        val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+        val localFile = createPreviewFile(entry)
+        val isPulled = adbClient.execute(PullRequest(entry.path, localFile, supportedFeatures), device.serial)
+        if (!isPulled) throw IOException("Failed to load ${entry.name}")
+        return localFile
+    }
+
+    private fun createPreviewFile(entry: AppFileEntry.File): File {
+        val extension = entry.extension()
+        val suffix = if (extension.isBlank()) ".tmp" else ".$extension"
+        return createTempFile(prefix = "adbpad-preview-", suffix = suffix)
+            .toFile()
+            .apply { deleteOnExit() }
+    }
+
     private fun getRootPath(
         app: InstalledApp,
         directory: AppDataDirectory,
@@ -182,7 +226,46 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
             "$this/$name"
         }
 
+    private fun AppFileEntry.File.isImageFile(): Boolean = extension() in IMAGE_FILE_EXTENSIONS
+
+    private fun AppFileEntry.File.isTextFile(): Boolean {
+        val normalizedName = name.lowercase(Locale.getDefault())
+        return extension() in TEXT_FILE_EXTENSIONS || normalizedName in TEXT_FILE_NAMES
+    }
+
+    private fun AppFileEntry.File.extension(): String =
+        name
+            .substringAfterLast('.', missingDelimiterValue = "")
+            .lowercase(Locale.getDefault())
+
     companion object {
         private const val PACKAGE_PREFIX = "package:"
+        private val IMAGE_FILE_EXTENSIONS = setOf("bmp", "gif", "jpeg", "jpg", "png", "webp")
+        private val TEXT_FILE_EXTENSIONS =
+            setOf(
+                "cfg",
+                "conf",
+                "css",
+                "csv",
+                "gradle",
+                "htm",
+                "html",
+                "ini",
+                "java",
+                "js",
+                "json",
+                "kt",
+                "kts",
+                "log",
+                "md",
+                "properties",
+                "sh",
+                "toml",
+                "txt",
+                "xml",
+                "yaml",
+                "yml",
+            )
+        private val TEXT_FILE_NAMES = setOf("changelog", "license", "notice", "readme")
     }
 }

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/app/AppFilePreview.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/app/AppFilePreview.kt
@@ -1,0 +1,21 @@
+package jp.kaleidot725.adbpad.domain.model.app
+
+import java.io.File
+
+sealed interface AppFilePreview {
+    val entry: AppFileEntry
+
+    data class Image(
+        override val entry: AppFileEntry.File,
+        val localFile: File,
+    ) : AppFilePreview
+
+    data class Text(
+        override val entry: AppFileEntry.File,
+        val text: String,
+    ) : AppFilePreview
+
+    data class Unsupported(
+        override val entry: AppFileEntry,
+    ) : AppFilePreview
+}

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -69,6 +69,10 @@ object Language : StringResources {
         get() = getCurrentResources().appFileTreeTitle
     override val appFileTreeEmpty: String
         get() = getCurrentResources().appFileTreeEmpty
+    override val appFilePreviewTitle: String
+        get() = getCurrentResources().appFilePreviewTitle
+    override val appFilePreviewNoImage: String
+        get() = getCurrentResources().appFilePreviewNoImage
     override val loadingAppFiles: String
         get() = getCurrentResources().loadingAppFiles
     override val installApp: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -35,7 +35,7 @@ object ChineseResources : StringResources {
     override val appFileTreeTitle: String = "文件"
     override val appFileTreeEmpty: String = "没有文件"
     override val appFilePreviewTitle: String = "预览"
-    override val appFilePreviewNoImage: String = "No image"
+    override val appFilePreviewNoImage: String = "双击预览"
     override val loadingAppFiles: String = "正在加载文件"
     override val installApp: String = "安装"
     override val selectInstallPackage: String = "选择要安装的 APK"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -34,6 +34,8 @@ object ChineseResources : StringResources {
     override val appSdCardDataDirectory: String = "SD 卡数据目录"
     override val appFileTreeTitle: String = "文件"
     override val appFileTreeEmpty: String = "没有文件"
+    override val appFilePreviewTitle: String = "预览"
+    override val appFilePreviewNoImage: String = "No image"
     override val loadingAppFiles: String = "正在加载文件"
     override val installApp: String = "安装"
     override val selectInstallPackage: String = "选择要安装的 APK"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -35,7 +35,7 @@ object EnglishResources : StringResources {
     override val appFileTreeTitle: String = "Files"
     override val appFileTreeEmpty: String = "No files"
     override val appFilePreviewTitle: String = "Preview"
-    override val appFilePreviewNoImage: String = "No image"
+    override val appFilePreviewNoImage: String = "Double-click to preview"
     override val loadingAppFiles: String = "Loading files"
     override val installApp: String = "Install"
     override val selectInstallPackage: String = "Select APK to install"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -34,6 +34,8 @@ object EnglishResources : StringResources {
     override val appSdCardDataDirectory: String = "SD card data directory"
     override val appFileTreeTitle: String = "Files"
     override val appFileTreeEmpty: String = "No files"
+    override val appFilePreviewTitle: String = "Preview"
+    override val appFilePreviewNoImage: String = "No image"
     override val loadingAppFiles: String = "Loading files"
     override val installApp: String = "Install"
     override val selectInstallPackage: String = "Select APK to install"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -35,7 +35,7 @@ object JapaneseResources : StringResources {
     override val appFileTreeTitle: String = "ファイル"
     override val appFileTreeEmpty: String = "ファイルがありません"
     override val appFilePreviewTitle: String = "プレビュー"
-    override val appFilePreviewNoImage: String = "No image"
+    override val appFilePreviewNoImage: String = "ダブルクリックでプレビューする"
     override val loadingAppFiles: String = "ファイルを取得中"
     override val installApp: String = "インストール"
     override val selectInstallPackage: String = "インストールするAPKを選択"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -34,6 +34,8 @@ object JapaneseResources : StringResources {
     override val appSdCardDataDirectory: String = "SDカードデータ領域"
     override val appFileTreeTitle: String = "ファイル"
     override val appFileTreeEmpty: String = "ファイルがありません"
+    override val appFilePreviewTitle: String = "プレビュー"
+    override val appFilePreviewNoImage: String = "No image"
     override val loadingAppFiles: String = "ファイルを取得中"
     override val installApp: String = "インストール"
     override val selectInstallPackage: String = "インストールするAPKを選択"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -33,6 +33,8 @@ interface StringResources {
     val appSdCardDataDirectory: String
     val appFileTreeTitle: String
     val appFileTreeEmpty: String
+    val appFilePreviewTitle: String
+    val appFilePreviewNoImage: String
     val loadingAppFiles: String
     val installApp: String
     val selectInstallPackage: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -35,7 +35,7 @@ object TurkishResources : StringResources {
     override val appFileTreeTitle: String = "Dosyalar"
     override val appFileTreeEmpty: String = "Dosya yok"
     override val appFilePreviewTitle: String = "Önizleme"
-    override val appFilePreviewNoImage: String = "No image"
+    override val appFilePreviewNoImage: String = "Önizlemek için çift tıkla"
     override val loadingAppFiles: String = "Dosyalar yükleniyor"
     override val installApp: String = "Yükle"
     override val selectInstallPackage: String = "Yüklenecek APK'yı seç"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -34,6 +34,8 @@ object TurkishResources : StringResources {
     override val appSdCardDataDirectory: String = "SD kart veri dizini"
     override val appFileTreeTitle: String = "Dosyalar"
     override val appFileTreeEmpty: String = "Dosya yok"
+    override val appFilePreviewTitle: String = "Önizleme"
+    override val appFilePreviewNoImage: String = "No image"
     override val loadingAppFiles: String = "Dosyalar yükleniyor"
     override val installApp: String = "Yükle"
     override val selectInstallPackage: String = "Yüklenecek APK'yı seç"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
@@ -36,4 +36,10 @@ interface InstalledAppRepository {
         device: Device,
         entry: AppFileEntry,
     ): Result<AppFilePreview, Exception>
+
+    suspend fun saveAppFile(
+        device: Device,
+        entry: AppFileEntry.File,
+        destination: File,
+    ): Result<Unit, Exception>
 }

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
@@ -3,6 +3,7 @@ package jp.kaleidot725.adbpad.domain.repository
 import com.github.michaelbull.result.Result
 import jp.kaleidot725.adbpad.domain.model.app.AppDataDirectory
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
+import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
 import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import java.io.File
@@ -30,4 +31,9 @@ interface InstalledAppRepository {
         device: Device,
         directory: AppFileEntry.Directory,
     ): Result<List<AppFileEntry>, Exception>
+
+    suspend fun getAppFilePreview(
+        device: Device,
+        entry: AppFileEntry,
+    ): Result<AppFilePreview, Exception>
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
@@ -82,6 +82,7 @@ fun AppScreen(
         right = {
             AppFilePreviewPane(
                 state = state.filePreview,
+                onSaveFile = { onAction(AppAction.SavePreviewFile) },
                 modifier = Modifier.fillMaxSize(),
             )
         },

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
@@ -13,6 +13,7 @@ import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.layout.ThreePaneLayout
 import jp.kaleidot725.adbpad.ui.screen.app.component.AppDetailPane
+import jp.kaleidot725.adbpad.ui.screen.app.component.AppFilePreviewPane
 import jp.kaleidot725.adbpad.ui.screen.app.component.AppHeader
 import jp.kaleidot725.adbpad.ui.screen.app.component.AppList
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppAction
@@ -73,6 +74,14 @@ fun AppScreen(
                 selectedSdCardDataFile = state.selectedSdCardDataFile,
                 onSelectDataFileNode = { onAction(AppAction.SelectDataFileNode(it)) },
                 onSelectSdCardDataFileNode = { onAction(AppAction.SelectSdCardDataFileNode(it)) },
+                onPreviewDataFileNode = { onAction(AppAction.PreviewDataFileNode(it)) },
+                onPreviewSdCardDataFileNode = { onAction(AppAction.PreviewSdCardDataFileNode(it)) },
+                modifier = Modifier.fillMaxSize(),
+            )
+        },
+        right = {
+            AppFilePreviewPane(
+                state = state.filePreview,
                 modifier = Modifier.fillMaxSize(),
             )
         },

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -54,6 +54,7 @@ class AppStateHolder(
                 is AppAction.SelectSdCardDataFileNode -> reduceSelectSdCardDataFileNode(uiAction.entry)
                 is AppAction.PreviewDataFileNode -> reducePreviewDataFileNode(uiAction.entry)
                 is AppAction.PreviewSdCardDataFileNode -> reducePreviewSdCardDataFileNode(uiAction.entry)
+                AppAction.SavePreviewFile -> reduceSavePreviewFile()
             }
         }
     }
@@ -150,6 +151,40 @@ class AppStateHolder(
         previewAppFile(entry)
     }
 
+    private suspend fun reduceSavePreviewFile() {
+        val device = currentState.selectedDevice ?: return
+        val entry = currentState.filePreview.entry as? AppFileEntry.File ?: return
+        if (currentState.filePreview.isSaving) return
+
+        val destination = selectSaveAppFile(entry) ?: return
+
+        update {
+            copy(
+                filePreview =
+                    filePreview.copy(
+                        isSaving = true,
+                        errorMessage = null,
+                    ),
+            )
+        }
+
+        val result = installedAppRepository.saveAppFile(device, entry, destination)
+        update {
+            copy(
+                filePreview =
+                    filePreview.copy(
+                        isSaving = false,
+                        errorMessage =
+                            if (result.isErr) {
+                                result.error.message ?: "Failed to save file"
+                            } else {
+                                null
+                            },
+                    ),
+            )
+        }
+    }
+
     private fun collectSelectedDevice() {
         coroutineScope.launch {
             getSelectedDeviceFlowUseCase().collectLatest { device ->
@@ -186,6 +221,19 @@ class AppStateHolder(
                 }
             val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
             val result = chooser.showOpenDialog(parent)
+            if (result == JFileChooser.APPROVE_OPTION) chooser.selectedFile else null
+        }
+
+    private suspend fun selectSaveAppFile(entry: AppFileEntry.File): File? =
+        withContext(Dispatchers.Swing) {
+            val chooser =
+                JFileChooser().apply {
+                    dialogTitle = Language.save
+                    fileSelectionMode = JFileChooser.FILES_ONLY
+                    selectedFile = File(entry.name)
+                }
+            val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            val result = chooser.showSaveDialog(parent)
             if (result == JFileChooser.APPROVE_OPTION) chooser.selectedFile else null
         }
 

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -86,9 +86,6 @@ class AppStateHolder(
         update {
             copy(
                 selectedAppIndex = apps.indexOf(app).takeIf { it >= 0 },
-                selectedDataFile = null,
-                selectedSdCardDataFile = null,
-                filePreview = AppFilePreviewState(),
             )
         }
     }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -378,8 +378,6 @@ class AppStateHolder(
 
     private suspend fun previewAppFile(entry: AppFileEntry) {
         val device = currentState.selectedDevice ?: return
-        val packageName = currentState.selectedApp?.packageName ?: return
-
         update {
             copy(
                 filePreview =
@@ -391,10 +389,6 @@ class AppStateHolder(
         }
 
         val result = installedAppRepository.getAppFilePreview(device, entry)
-        if (currentState.selectedDevice != device) return
-        if (currentState.selectedApp?.packageName != packageName) return
-        if (currentState.filePreview.entry?.path != entry.path) return
-
         update {
             if (result.isOk) {
                 copy(

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -10,6 +10,7 @@ import jp.kaleidot725.adbpad.domain.repository.InstalledAppRepository
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppAction
+import jp.kaleidot725.adbpad.ui.screen.app.state.AppFilePreviewState
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFileTreeState
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppProcessState
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppSideEffect
@@ -51,6 +52,8 @@ class AppStateHolder(
                 AppAction.SelectPreviousApp -> reduceSelectPreviousApp()
                 is AppAction.SelectDataFileNode -> reduceSelectDataFileNode(uiAction.entry)
                 is AppAction.SelectSdCardDataFileNode -> reduceSelectSdCardDataFileNode(uiAction.entry)
+                is AppAction.PreviewDataFileNode -> reducePreviewDataFileNode(uiAction.entry)
+                is AppAction.PreviewSdCardDataFileNode -> reducePreviewSdCardDataFileNode(uiAction.entry)
             }
         }
     }
@@ -83,6 +86,9 @@ class AppStateHolder(
         update {
             copy(
                 selectedAppIndex = apps.indexOf(app).takeIf { it >= 0 },
+                selectedDataFile = null,
+                selectedSdCardDataFile = null,
+                filePreview = AppFilePreviewState(),
             )
         }
     }
@@ -135,6 +141,16 @@ class AppStateHolder(
         if (entry is AppFileEntry.Directory) {
             toggleSdCardDataAppDirectory(entry)
         }
+    }
+
+    private suspend fun reducePreviewDataFileNode(entry: AppFileEntry) {
+        update { copy(selectedDataFile = entry) }
+        previewAppFile(entry)
+    }
+
+    private suspend fun reducePreviewSdCardDataFileNode(entry: AppFileEntry) {
+        update { copy(selectedSdCardDataFile = entry) }
+        previewAppFile(entry)
     }
 
     private fun collectSelectedDevice() {
@@ -213,6 +229,7 @@ class AppStateHolder(
                     sdCardDataFileTree = AppFileTreeState(),
                     selectedDataFile = null,
                     selectedSdCardDataFile = null,
+                    filePreview = AppFilePreviewState(),
                 )
             }
         } else {
@@ -359,6 +376,46 @@ class AppStateHolder(
                 }
 
             updateTree(nextTree)
+        }
+    }
+
+    private suspend fun previewAppFile(entry: AppFileEntry) {
+        val device = currentState.selectedDevice ?: return
+        val packageName = currentState.selectedApp?.packageName ?: return
+
+        update {
+            copy(
+                filePreview =
+                    AppFilePreviewState(
+                        entry = entry,
+                        isLoading = true,
+                    ),
+            )
+        }
+
+        val result = installedAppRepository.getAppFilePreview(device, entry)
+        if (currentState.selectedDevice != device) return
+        if (currentState.selectedApp?.packageName != packageName) return
+        if (currentState.filePreview.entry?.path != entry.path) return
+
+        update {
+            if (result.isOk) {
+                copy(
+                    filePreview =
+                        AppFilePreviewState(
+                            entry = entry,
+                            preview = result.value,
+                        ),
+                )
+            } else {
+                copy(
+                    filePreview =
+                        AppFilePreviewState(
+                            entry = entry,
+                            errorMessage = result.error.message ?: "Failed to load preview",
+                        ),
+                )
+            }
         }
     }
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppDetailPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppDetailPane.kt
@@ -33,6 +33,8 @@ fun AppDetailPane(
     selectedSdCardDataFile: AppFileEntry?,
     onSelectDataFileNode: (AppFileEntry) -> Unit,
     onSelectSdCardDataFileNode: (AppFileEntry) -> Unit,
+    onPreviewDataFileNode: (AppFileEntry) -> Unit,
+    onPreviewSdCardDataFileNode: (AppFileEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (app == null) {
@@ -93,6 +95,7 @@ fun AppDetailPane(
                     tree = dataFileTree,
                     selectedFile = selectedDataFile,
                     onSelectNode = onSelectDataFileNode,
+                    onPreviewNode = onPreviewDataFileNode,
                 )
             }
 
@@ -105,6 +108,7 @@ fun AppDetailPane(
                     tree = sdCardDataFileTree,
                     selectedFile = selectedSdCardDataFile,
                     onSelectNode = onSelectSdCardDataFileNode,
+                    onPreviewNode = onPreviewSdCardDataFileNode,
                 )
             }
         }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -35,6 +36,7 @@ import coil3.compose.AsyncImage
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Minus
 import com.composables.icons.lucide.Plus
+import com.composables.icons.lucide.Save
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
 import jp.kaleidot725.adbpad.domain.model.language.Language
@@ -49,11 +51,14 @@ import net.engawapg.lib.zoomable.zoomable
 @Composable
 fun AppFilePreviewPane(
     state: AppFilePreviewState,
+    onSaveFile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         AppFilePreviewHeader(
             entry = state.entry,
+            canSave = state.entry is AppFileEntry.File && !state.isLoading && !state.isSaving,
+            onSaveFile = onSaveFile,
             modifier = Modifier.fillMaxWidth().padding(16.dp),
         )
 
@@ -93,17 +98,31 @@ fun AppFilePreviewPane(
 @Composable
 private fun AppFilePreviewHeader(
     entry: AppFileEntry?,
+    canSave: Boolean,
+    onSaveFile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Text(
-            text = Language.appFilePreviewTitle,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = Language.appFilePreviewTitle,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f),
+            )
+            CommandIconButton(
+                image = Lucide.Save,
+                onClick = onSaveFile,
+                enabled = canSave,
+                modifier = Modifier.size(32.dp),
+            )
+        }
         if (entry != null) {
             Text(
                 text = entry.name,
@@ -286,6 +305,7 @@ private fun AppFilePreviewPanePreview() {
                         text = "{\n  \"enabled\": true\n}",
                     ),
             ),
+        onSaveFile = {},
         modifier = Modifier.fillMaxSize(),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
@@ -1,13 +1,18 @@
 package jp.kaleidot725.adbpad.ui.screen.app.component
 
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -15,20 +20,31 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Minus
+import com.composables.icons.lucide.Plus
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
+import jp.kaleidot725.adbpad.ui.component.button.CommandIconButton
+import jp.kaleidot725.adbpad.ui.component.button.CommandTextButton
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFilePreviewState
+import kotlinx.coroutines.launch
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 
 @Composable
 fun AppFilePreviewPane(
@@ -43,7 +59,7 @@ fun AppFilePreviewPane(
 
         HorizontalDivider(color = UserColor.getSplitterColor())
 
-        Box(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Box(modifier = Modifier.fillMaxSize()) {
             when {
                 state.isLoading -> {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -51,25 +67,23 @@ fun AppFilePreviewPane(
                 state.errorMessage != null -> {
                     AppFilePreviewNoImage(
                         details = state.errorMessage,
-                        modifier = Modifier.align(Alignment.Center),
+                        modifier = Modifier.align(Alignment.Center).padding(16.dp),
                     )
                 }
                 state.preview is AppFilePreview.Image -> {
-                    AsyncImage(
-                        model = state.preview.localFile,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
+                    AppFileImagePreview(
+                        preview = state.preview,
                         modifier = Modifier.fillMaxSize(),
                     )
                 }
                 state.preview is AppFilePreview.Text -> {
                     AppFileTextPreview(
                         text = state.preview.text,
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxSize().padding(16.dp),
                     )
                 }
                 else -> {
-                    AppFilePreviewNoImage(modifier = Modifier.align(Alignment.Center))
+                    AppFilePreviewNoImage(modifier = Modifier.align(Alignment.Center).padding(16.dp))
                 }
             }
         }
@@ -103,6 +117,95 @@ private fun AppFilePreviewHeader(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppFileImagePreview(
+    preview: AppFilePreview.Image,
+    modifier: Modifier = Modifier,
+) {
+    val zoomState = rememberZoomState()
+    val coroutineScope = rememberCoroutineScope()
+
+    BoxWithConstraints(modifier = modifier) {
+        val constraints = this
+
+        AsyncImage(
+            model = preview.localFile,
+            contentDescription = null,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .clip(RectangleShape)
+                    .zoomable(zoomState),
+        )
+
+        Column(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(12.dp)
+                    .background(
+                        color = UserColor.getFloatingBackgroundColor(),
+                        shape = RoundedCornerShape(4.dp),
+                    ),
+        ) {
+            CommandIconButton(
+                image = Lucide.Plus,
+                onClick = {
+                    coroutineScope.launch {
+                        zoomState.changeScale(
+                            targetScale = zoomState.scale + 0.5f,
+                            position =
+                                Offset(
+                                    constraints.maxWidth.value / 2f,
+                                    constraints.maxHeight.value / 2f,
+                                ),
+                            animationSpec = tween(),
+                        )
+                    }
+                },
+                modifier =
+                    Modifier
+                        .padding(4.dp)
+                        .size(32.dp),
+            )
+
+            CommandIconButton(
+                image = Lucide.Minus,
+                onClick = {
+                    coroutineScope.launch {
+                        zoomState.changeScale(
+                            targetScale = zoomState.scale - 0.5f,
+                            position =
+                                Offset(
+                                    constraints.maxWidth.value / 2f,
+                                    constraints.maxHeight.value / 2f,
+                                ),
+                            animationSpec = tween(),
+                        )
+                    }
+                },
+                modifier =
+                    Modifier
+                        .padding(4.dp)
+                        .size(32.dp),
+            )
+
+            CommandTextButton(
+                text = "100%",
+                onClick = {
+                    coroutineScope.launch {
+                        zoomState.reset()
+                    }
+                },
+                modifier =
+                    Modifier
+                        .padding(4.dp)
+                        .size(32.dp),
             )
         }
     }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
@@ -1,0 +1,188 @@
+package jp.kaleidot725.adbpad.ui.screen.app.component
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
+import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
+import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.common.resource.UserColor
+import jp.kaleidot725.adbpad.ui.screen.app.state.AppFilePreviewState
+
+@Composable
+fun AppFilePreviewPane(
+    state: AppFilePreviewState,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        AppFilePreviewHeader(
+            entry = state.entry,
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        )
+
+        HorizontalDivider(color = UserColor.getSplitterColor())
+
+        Box(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            when {
+                state.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                state.errorMessage != null -> {
+                    AppFilePreviewNoImage(
+                        details = state.errorMessage,
+                        modifier = Modifier.align(Alignment.Center),
+                    )
+                }
+                state.preview is AppFilePreview.Image -> {
+                    AsyncImage(
+                        model = state.preview.localFile,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+                state.preview is AppFilePreview.Text -> {
+                    AppFileTextPreview(
+                        text = state.preview.text,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+                else -> {
+                    AppFilePreviewNoImage(modifier = Modifier.align(Alignment.Center))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppFilePreviewHeader(
+    entry: AppFileEntry?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = Language.appFilePreviewTitle,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        if (entry != null) {
+            Text(
+                text = entry.name,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = entry.path,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppFileTextPreview(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    val verticalScrollState = rememberScrollState()
+    val horizontalScrollState = rememberScrollState()
+
+    SelectionContainer {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+            modifier =
+                modifier
+                    .verticalScroll(verticalScrollState)
+                    .horizontalScroll(horizontalScrollState),
+        )
+    }
+}
+
+@Composable
+private fun AppFilePreviewNoImage(
+    details: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = Language.appFilePreviewNoImage,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (!details.isNullOrBlank()) {
+            Text(
+                text = details,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AppFilePreviewPanePreview() {
+    AppFilePreviewPane(
+        state =
+            AppFilePreviewState(
+                entry =
+                    AppFileEntry.File(
+                        name = "settings.json",
+                        path = "/data/data/com.example/files/settings.json",
+                        permissions = "-rw-r--r--",
+                        size = 128,
+                        date = "2026-05-10",
+                        time = "12:00",
+                    ),
+                preview =
+                    AppFilePreview.Text(
+                        entry =
+                            AppFileEntry.File(
+                                name = "settings.json",
+                                path = "/data/data/com.example/files/settings.json",
+                                permissions = "-rw-r--r--",
+                                size = 128,
+                                date = "2026-05-10",
+                                time = "12:00",
+                            ),
+                        text = "{\n  \"enabled\": true\n}",
+                    ),
+            ),
+        modifier = Modifier.fillMaxSize(),
+    )
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeNode.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeNode.kt
@@ -1,6 +1,7 @@
 package jp.kaleidot725.adbpad.ui.screen.app.component.tree
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,12 +30,14 @@ import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFileTreeState
 
 @Composable
+@OptIn(ExperimentalFoundationApi::class)
 internal fun AppFileTreeNode(
     entry: AppFileEntry,
     tree: AppFileTreeState,
     depth: Int,
     selectedFile: AppFileEntry?,
     onSelectNode: (AppFileEntry) -> Unit,
+    onPreviewNode: (AppFileEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isExpanded = tree.expandedPaths.contains(entry.path)
@@ -51,7 +54,16 @@ internal fun AppFileTreeNode(
                     .clickableBackground(
                         isSelected = isSelected,
                         shape = RoundedCornerShape(4.dp),
-                    ).clickable { onSelectNode(entry) }
+                    ).combinedClickable(
+                        onClick = { onSelectNode(entry) },
+                        onDoubleClick = {
+                            if (entry.isDirectory) {
+                                onSelectNode(entry)
+                            } else {
+                                onPreviewNode(entry)
+                            }
+                        },
+                    )
                     .padding(start = (depth * 16).dp, top = 4.dp, end = 4.dp, bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -110,6 +122,7 @@ internal fun AppFileTreeNode(
                             depth = depth + 1,
                             selectedFile = selectedFile,
                             onSelectNode = onSelectNode,
+                            onPreviewNode = onPreviewNode,
                         )
                     }
                 }
@@ -133,6 +146,7 @@ private fun AppFileTreeNodePreview() {
         depth = 0,
         selectedFile = directory,
         onSelectNode = {},
+        onPreviewNode = {},
         modifier = Modifier.width(280.dp).padding(16.dp),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeView.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeView.kt
@@ -17,6 +17,7 @@ fun AppFileTreeView(
     tree: AppFileTreeState,
     selectedFile: AppFileEntry?,
     onSelectNode: (AppFileEntry) -> Unit,
+    onPreviewNode: (AppFileEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -32,6 +33,7 @@ fun AppFileTreeView(
                         depth = 0,
                         selectedFile = selectedFile,
                         onSelectNode = onSelectNode,
+                        onPreviewNode = onPreviewNode,
                     )
                 }
             }
@@ -53,6 +55,7 @@ private fun AppFileTreeViewPreview() {
             ),
         selectedFile = directory,
         onSelectNode = {},
+        onPreviewNode = {},
         modifier = Modifier.width(280.dp).padding(16.dp),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
@@ -45,4 +45,6 @@ sealed class AppAction : PulseAction {
     data class PreviewSdCardDataFileNode(
         val entry: AppFileEntry,
     ) : AppAction()
+
+    data object SavePreviewFile : AppAction()
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
@@ -37,4 +37,12 @@ sealed class AppAction : PulseAction {
     data class SelectSdCardDataFileNode(
         val entry: AppFileEntry,
     ) : AppAction()
+
+    data class PreviewDataFileNode(
+        val entry: AppFileEntry,
+    ) : AppAction()
+
+    data class PreviewSdCardDataFileNode(
+        val entry: AppFileEntry,
+    ) : AppAction()
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppState.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppState.kt
@@ -75,5 +75,6 @@ data class AppFilePreviewState(
     val entry: AppFileEntry? = null,
     val preview: AppFilePreview? = null,
     val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
     val errorMessage: String? = null,
 )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppState.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppState.kt
@@ -1,6 +1,7 @@
 package jp.kaleidot725.adbpad.ui.screen.app.state
 
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
+import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
 import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.domain.model.device.Device
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
@@ -18,6 +19,7 @@ data class AppState(
     val selectedDataFile: AppFileEntry? = null,
     val sdCardDataFileTree: AppFileTreeState = AppFileTreeState(),
     val selectedSdCardDataFile: AppFileEntry? = null,
+    val filePreview: AppFilePreviewState = AppFilePreviewState(),
 ) : PulseState {
     val isLoading: Boolean = processState == AppProcessState.Loading
     val isUninstalling: Boolean = processState == AppProcessState.Uninstalling
@@ -65,6 +67,13 @@ data class AppFileTreeState(
     val childrenByPath: Map<String, List<AppFileEntry>> = emptyMap(),
     val loadingPaths: Set<String> = emptySet(),
     val errorMessages: Map<String, String> = emptyMap(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+data class AppFilePreviewState(
+    val entry: AppFileEntry? = null,
+    val preview: AppFilePreview? = null,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 )


### PR DESCRIPTION
## Summary
- Add an app file preview model and repository API to fetch previews from the device.
- Wire the App screen so double-clicking a file loads the right-pane preview.
- Render image previews, text previews, and a `No image` fallback for unsupported files.
- Add localized strings for the new preview pane labels.

## Testing
- `./gradlew compileKotlinJvm`
- Targeted ktlint checks for the changed JVM source sets passed.
- Full `./gradlew ktlintCheck` still reports pre-existing violations in `core:view` layout files that were not part of this change.