### PR TITLE
Fix stale app file tree cache on directory reopen

### DIFF
--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -99,8 +99,8 @@ class AppStateHolder(
 
         update { copy(processState = AppProcessState.Installing) }
         val isInstalled = installedAppRepository.installPackage(device, packageFile)
+        if (isInstalled) refreshApps(device)
         update { copy(processState = AppProcessState.Idle) }
-        if (isInstalled) reduceRefreshApps()
     }
 
     private suspend fun reduceUninstallApp(app: InstalledApp) {
@@ -109,8 +109,8 @@ class AppStateHolder(
 
         update { copy(processState = AppProcessState.Uninstalling) }
         val isUninstalled = installedAppRepository.uninstallInstalledApp(device, app)
+        if (isUninstalled) refreshApps(device)
         update { copy(processState = AppProcessState.Idle) }
-        if (isUninstalled) reduceRefreshApps()
     }
 
     private suspend fun reduceSelectNextApp() {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -368,18 +368,32 @@ class AppStateHolder(
 
         update {
             val currentTree = selectTree()
-            val expandedPaths =
+            val nextTree =
                 if (isExpanded) {
-                    currentTree.expandedPaths - entry.path
+                    currentTree.clearDirectoryCache(entry.path)
                 } else {
-                    currentTree.expandedPaths + entry.path
+                    currentTree.copy(expandedPaths = currentTree.expandedPaths + entry.path)
                 }
-            updateTree(currentTree.copy(expandedPaths = expandedPaths))
+            updateTree(nextTree)
         }
 
         if (!isExpanded && !isLoaded) {
             loadAppFileTreeChildren(entry, selectTree, updateTree)
         }
+    }
+
+    private fun AppFileTreeState.clearDirectoryCache(path: String): AppFileTreeState =
+        copy(
+            expandedPaths = expandedPaths.filterNot { it.isSameOrChildPath(path) }.toSet(),
+            childrenByPath = childrenByPath.filterKeys { !it.isSameOrChildPath(path) },
+            loadingPaths = loadingPaths.filterNot { it.isSameOrChildPath(path) }.toSet(),
+            errorMessages = errorMessages.filterKeys { !it.isSameOrChildPath(path) },
+        )
+
+    private fun String.isSameOrChildPath(parentPath: String): Boolean {
+        val parent = parentPath.trimEnd('/')
+        val current = trimEnd('/')
+        return current == parent || current.startsWith("$parent/")
     }
 
     private suspend fun loadAppFileTreeChildren(
@@ -402,6 +416,7 @@ class AppStateHolder(
 
         val result = installedAppRepository.getAppFileChildren(device, entry)
         if (currentState.selectedApp?.packageName != packageName) return
+        if (!currentState.selectTree().loadingPaths.contains(entry.path)) return
 
         update {
             val tree = selectTree()


### PR DESCRIPTION
## Summary

Fix stale app file tree data when reopening device directories.

## Changes

- Clear cached child entries when a file tree directory is collapsed.
- Clear nested expanded/loading/error state for the collapsed directory subtree.
- Force directories to reload from the device the next time they are expanded.
- Ignore stale async load results if the directory was collapsed before loading completed.

## Verification

- Ran `./gradlew compileKotlinJvm -Dkotlin.daemon.jvm.options=-Xmx2048m -Dorg.gradle.jvmargs=-Xmx2048m`
- Ran `./gradlew :runKtlintCheckOverJvmMainSourceSet`
