### PR TITLE
Add context menus for app file tree nodes

### DIFF
--- a/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
+++ b/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
@@ -173,6 +173,79 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
             }
         }
 
+    override suspend fun uploadAppFile(
+        device: Device,
+        source: File,
+        destination: AppFileEntry,
+    ): Result<Unit, Exception> =
+        withContext(Dispatchers.IO) {
+            try {
+                if (!source.isFile) throw IOException("${source.name} is not a file")
+
+                val destinationPath =
+                    when (destination) {
+                        is AppFileEntry.Directory -> destination.path.resolveChildPath(source.name)
+                        else -> destination.path
+                    }
+                val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+                val isPushed = adbClient.execute(PushRequest(source, destinationPath, supportedFeatures), device.serial)
+                if (!isPushed) throw IOException("Failed to upload ${source.name}")
+                Ok(Unit)
+            } catch (exception: Exception) {
+                if (exception is CancellationException) throw exception
+                Err(exception)
+            }
+        }
+
+    override suspend fun deleteAppFile(
+        device: Device,
+        entry: AppFileEntry,
+    ): Result<Unit, Exception> =
+        withContext(Dispatchers.IO) {
+            try {
+                val command =
+                    if (entry is AppFileEntry.Directory) {
+                        "rm -rf ${entry.path.toShellArgument()}"
+                    } else {
+                        "rm -f ${entry.path.toShellArgument()}"
+                    }
+                val result = adbClient.execute(ShellCommandRequest(command), device.serial)
+                if (result.exitCode != 0) {
+                    throw IOException(result.output.ifBlank { "Failed to delete ${entry.name}" })
+                }
+                Ok(Unit)
+            } catch (exception: Exception) {
+                if (exception is CancellationException) throw exception
+                Err(exception)
+            }
+        }
+
+    override suspend fun renameAppFile(
+        device: Device,
+        entry: AppFileEntry,
+        name: String,
+    ): Result<Unit, Exception> =
+        withContext(Dispatchers.IO) {
+            try {
+                val normalizedName = name.trim()
+                if (normalizedName.isBlank() || normalizedName.contains("/")) {
+                    throw IOException("Invalid name")
+                }
+
+                val parentPath = entry.parentPath() ?: throw IOException("Cannot rename ${entry.name}")
+                val destinationPath = parentPath.resolveChildPath(normalizedName)
+                val command = "mv ${entry.path.toShellArgument()} ${destinationPath.toShellArgument()}"
+                val result = adbClient.execute(ShellCommandRequest(command), device.serial)
+                if (result.exitCode != 0) {
+                    throw IOException(result.output.ifBlank { "Failed to rename ${entry.name}" })
+                }
+                Ok(Unit)
+            } catch (exception: Exception) {
+                if (exception is CancellationException) throw exception
+                Err(exception)
+            }
+        }
+
     private suspend fun pullAppFile(
         device: Device,
         entry: AppFileEntry.File,
@@ -293,6 +366,14 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
         } else {
             "$this/$name"
         }
+
+    private fun AppFileEntry.parentPath(): String? =
+        path
+            .trimEnd('/')
+            .substringBeforeLast('/', missingDelimiterValue = "")
+            .takeIf { it.isNotBlank() }
+
+    private fun String.toShellArgument(): String = "'${replace("'", "'\"'\"'")}'"
 
     private fun AppFileEntry.File.isImageFile(): Boolean = extension() in IMAGE_FILE_EXTENSIONS
 

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -31,6 +31,8 @@ object Language : StringResources {
         get() = getCurrentResources().upload
     override val download: String
         get() = getCurrentResources().download
+    override val rename: String
+        get() = getCurrentResources().rename
     override val send: String
         get() = getCurrentResources().send
     override val cancel: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -14,6 +14,7 @@ object ChineseResources : StringResources {
     override val delete = "删除"
     override val upload = "上传"
     override val download = "下载"
+    override val rename = "重命名"
     override val tab = "标签"
     override val send = "发送"
     override val cancel = "取消"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -14,6 +14,7 @@ object EnglishResources : StringResources {
     override val delete = "Delete"
     override val upload = "Upload"
     override val download = "Download"
+    override val rename = "Rename"
     override val tab = "Tab"
     override val send = "Send"
     override val cancel = "Cancel"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -14,6 +14,7 @@ object JapaneseResources : StringResources {
     override val delete = "削除"
     override val upload = "アップロード"
     override val download = "ダウンロード"
+    override val rename = "名称を変更"
     override val tab = "Tab"
     override val send = "送信"
     override val cancel = "キャンセル"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -13,6 +13,7 @@ interface StringResources {
     val delete: String
     val upload: String
     val download: String
+    val rename: String
     val tab: String
     val send: String
     val cancel: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -14,6 +14,7 @@ object TurkishResources : StringResources {
     override val delete = "Sil"
     override val upload = "Karşıya yükle"
     override val download = "İndir"
+    override val rename = "Yeniden adlandır"
     override val tab = "Sekme"
     override val send = "Gönder"
     override val cancel = "İptal"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
@@ -48,4 +48,21 @@ interface InstalledAppRepository {
         source: File,
         destination: AppFileEntry.File,
     ): Result<Unit, Exception>
+
+    suspend fun uploadAppFile(
+        device: Device,
+        source: File,
+        destination: AppFileEntry,
+    ): Result<Unit, Exception>
+
+    suspend fun deleteAppFile(
+        device: Device,
+        entry: AppFileEntry,
+    ): Result<Unit, Exception>
+
+    suspend fun renameAppFile(
+        device: Device,
+        entry: AppFileEntry,
+        name: String,
+    ): Result<Unit, Exception>
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import jp.kaleidot725.adbpad.domain.model.app.AppDataDirectory
 import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.ui.common.resource.UserColor
 import jp.kaleidot725.adbpad.ui.component.layout.ThreePaneLayout
@@ -76,6 +77,14 @@ fun AppScreen(
                 onSelectSdCardDataFileNode = { onAction(AppAction.SelectSdCardDataFileNode(it)) },
                 onPreviewDataFileNode = { onAction(AppAction.PreviewDataFileNode(it)) },
                 onPreviewSdCardDataFileNode = { onAction(AppAction.PreviewSdCardDataFileNode(it)) },
+                onUploadDataFileNode = { onAction(AppAction.UploadAppFileNode(AppDataDirectory.Data, it)) },
+                onUploadSdCardDataFileNode = { onAction(AppAction.UploadAppFileNode(AppDataDirectory.SdCardData, it)) },
+                onDeleteDataFileNode = { onAction(AppAction.DeleteAppFileNode(AppDataDirectory.Data, it)) },
+                onDeleteSdCardDataFileNode = { onAction(AppAction.DeleteAppFileNode(AppDataDirectory.SdCardData, it)) },
+                onRefreshDataFileNode = { onAction(AppAction.RefreshAppFileNode(AppDataDirectory.Data, it)) },
+                onRefreshSdCardDataFileNode = { onAction(AppAction.RefreshAppFileNode(AppDataDirectory.SdCardData, it)) },
+                onRenameDataFileNode = { onAction(AppAction.RenameAppFileNode(AppDataDirectory.Data, it)) },
+                onRenameSdCardDataFileNode = { onAction(AppAction.RenameAppFileNode(AppDataDirectory.SdCardData, it)) },
                 modifier = Modifier.fillMaxSize(),
             )
         },

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -55,6 +55,10 @@ class AppStateHolder(
                 is AppAction.SelectSdCardDataFileNode -> reduceSelectSdCardDataFileNode(uiAction.entry)
                 is AppAction.PreviewDataFileNode -> reducePreviewDataFileNode(uiAction.entry)
                 is AppAction.PreviewSdCardDataFileNode -> reducePreviewSdCardDataFileNode(uiAction.entry)
+                is AppAction.UploadAppFileNode -> reduceUploadAppFileNode(uiAction.directory, uiAction.entry)
+                is AppAction.DeleteAppFileNode -> reduceDeleteAppFileNode(uiAction.directory, uiAction.entry)
+                is AppAction.RefreshAppFileNode -> reduceRefreshAppFileNode(uiAction.directory, uiAction.entry)
+                is AppAction.RenameAppFileNode -> reduceRenameAppFileNode(uiAction.directory, uiAction.entry)
                 AppAction.SavePreviewFile -> reduceSavePreviewFile()
                 AppAction.OverwritePreviewFile -> reduceOverwritePreviewFile()
             }
@@ -112,6 +116,89 @@ class AppStateHolder(
 
     private fun AppFileEntry?.replaceIfSamePath(entry: AppFileEntry): AppFileEntry? =
         if (this?.path == entry.path) entry else this
+
+    private suspend fun reduceUploadAppFileNode(
+        directory: AppDataDirectory,
+        entry: AppFileEntry,
+    ) {
+        val device = currentState.selectedDevice ?: return
+        val source = selectUploadAppFile(entry) ?: return
+        if (entry !is AppFileEntry.Directory && !confirmOverwriteAppFile(entry, source)) return
+
+        val result = installedAppRepository.uploadAppFile(device, source, entry)
+        if (result.isOk) {
+            if (entry is AppFileEntry.Directory) {
+                refreshAppFileTreeDirectory(directory, entry, expand = true)
+            } else {
+                val updatedEntry = entry.withUpdatedSize(source.length())
+                update {
+                    updateSelectedFile(
+                        directory = directory,
+                        selectedFile = selectedFile(directory).replaceIfSamePath(updatedEntry),
+                    )
+                }
+                refreshAppFileTreeParent(directory, entry)
+                if (currentState.filePreview.entry?.path == entry.path) {
+                    previewAppFile(updatedEntry)
+                }
+            }
+        } else {
+            showAppFileOperationError(Language.upload, result.error)
+        }
+    }
+
+    private suspend fun reduceDeleteAppFileNode(
+        directory: AppDataDirectory,
+        entry: AppFileEntry,
+    ) {
+        val device = currentState.selectedDevice ?: return
+        if (!confirmDeleteAppFile(entry)) return
+
+        val result = installedAppRepository.deleteAppFile(device, entry)
+        if (result.isOk) {
+            update {
+                updateFileTree(directory, selectFileTree(directory).clearDirectoryCache(entry.path))
+                    .clearAppFileSelection(directory, entry)
+            }
+            refreshAppFileTreeParent(directory, entry)
+        } else {
+            showAppFileOperationError(Language.delete, result.error)
+        }
+    }
+
+    private suspend fun reduceRefreshAppFileNode(
+        directory: AppDataDirectory,
+        entry: AppFileEntry,
+    ) {
+        if (entry is AppFileEntry.Directory) {
+            refreshAppFileTreeDirectory(directory, entry, expand = true)
+        } else {
+            refreshAppFileTreeParent(directory, entry)
+            if (currentState.filePreview.entry?.path == entry.path) {
+                previewAppFile(entry)
+            }
+        }
+    }
+
+    private suspend fun reduceRenameAppFileNode(
+        directory: AppDataDirectory,
+        entry: AppFileEntry,
+    ) {
+        val device = currentState.selectedDevice ?: return
+        val newName = inputAppFileName(entry) ?: return
+        if (newName == entry.name) return
+
+        val result = installedAppRepository.renameAppFile(device, entry, newName)
+        if (result.isOk) {
+            update {
+                updateFileTree(directory, selectFileTree(directory).clearDirectoryCache(entry.path))
+                    .clearAppFileSelection(directory, entry)
+            }
+            refreshAppFileTreeParent(directory, entry)
+        } else {
+            showAppFileOperationError(Language.rename, result.error)
+        }
+    }
 
     private suspend fun reduceRefreshApps() {
         if (currentState.processState != AppProcessState.Idle) return
@@ -283,6 +370,23 @@ class AppStateHolder(
             if (result == JFileChooser.APPROVE_OPTION) chooser.selectedFile else null
         }
 
+    private suspend fun selectUploadAppFile(entry: AppFileEntry): File? =
+        withContext(Dispatchers.Swing) {
+            val chooser =
+                JFileChooser().apply {
+                    dialogTitle =
+                        if (entry is AppFileEntry.Directory) {
+                            "Upload file to ${entry.name}"
+                        } else {
+                            "Upload file to replace ${entry.name}"
+                        }
+                    fileSelectionMode = JFileChooser.FILES_ONLY
+                }
+            val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            val result = chooser.showOpenDialog(parent)
+            if (result == JFileChooser.APPROVE_OPTION) chooser.selectedFile else null
+        }
+
     private suspend fun selectOverwriteAppFile(entry: AppFileEntry.File): File? =
         withContext(Dispatchers.Swing) {
             val chooser =
@@ -301,7 +405,7 @@ class AppStateHolder(
     }
 
     private suspend fun confirmOverwriteAppFile(
-        entry: AppFileEntry.File,
+        entry: AppFileEntry,
         source: File,
     ): Boolean =
         withContext(Dispatchers.Swing) {
@@ -316,6 +420,77 @@ class AppStateHolder(
                 )
             result == JOptionPane.YES_OPTION
         }
+
+    private suspend fun confirmDeleteAppFile(entry: AppFileEntry): Boolean =
+        withContext(Dispatchers.Swing) {
+            val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            val targetType = if (entry is AppFileEntry.Directory) "directory" else "file"
+            val result =
+                JOptionPane.showConfirmDialog(
+                    parent,
+                    "Delete $targetType ${entry.name}?",
+                    Language.delete,
+                    JOptionPane.YES_NO_OPTION,
+                    JOptionPane.WARNING_MESSAGE,
+                )
+            result == JOptionPane.YES_OPTION
+        }
+
+    private suspend fun inputAppFileName(entry: AppFileEntry): String? =
+        withContext<String?>(Dispatchers.Swing) {
+            val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            var selectedName: String? = null
+            var isSelecting = true
+            while (isSelecting) {
+                val input =
+                    JOptionPane.showInputDialog(
+                        parent,
+                        "New name",
+                        Language.rename,
+                        JOptionPane.PLAIN_MESSAGE,
+                        null,
+                        null,
+                        entry.name,
+                    ) as? String
+
+                if (input == null) {
+                    isSelecting = false
+                } else {
+                    val name = input.trim()
+                    when {
+                        name.isBlank() -> isSelecting = false
+                        name.contains("/") -> {
+                            JOptionPane.showMessageDialog(
+                                parent,
+                                "Name cannot contain /",
+                                Language.rename,
+                                JOptionPane.ERROR_MESSAGE,
+                            )
+                        }
+                        else -> {
+                            selectedName = name
+                            isSelecting = false
+                        }
+                    }
+                }
+            }
+            selectedName
+        }
+
+    private suspend fun showAppFileOperationError(
+        title: String,
+        exception: Exception,
+    ) {
+        withContext(Dispatchers.Swing) {
+            val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            JOptionPane.showMessageDialog(
+                parent,
+                exception.message ?: "Failed to update file",
+                title,
+                JOptionPane.ERROR_MESSAGE,
+            )
+        }
+    }
 
     private fun selectNextOrPreviousApp(offset: Int): Int {
         val filteredApps = currentState.filteredApps
@@ -376,6 +551,79 @@ class AppStateHolder(
 
         refreshDataAppFileTree(device, app)
         refreshSdCardDataAppFileTree(device, app)
+    }
+
+    private suspend fun refreshCurrentAppFileTree(directory: AppDataDirectory) {
+        val device = currentState.selectedDevice ?: return
+        val app = currentState.selectedApp ?: return
+
+        when (directory) {
+            AppDataDirectory.Data -> refreshDataAppFileTree(device, app)
+            AppDataDirectory.SdCardData -> refreshSdCardDataAppFileTree(device, app)
+        }
+    }
+
+    private suspend fun refreshAppFileTreeParent(
+        directory: AppDataDirectory,
+        entry: AppFileEntry,
+    ) {
+        val app = currentState.selectedApp ?: return
+        val parentPath = entry.parentPath() ?: return
+        val rootPath = app.rootPath(directory).trimEnd('/')
+
+        if (parentPath.trimEnd('/') == rootPath) {
+            refreshCurrentAppFileTree(directory)
+        } else {
+            refreshAppFileTreeDirectory(
+                directory = directory,
+                entry = parentPath.toDirectoryEntry(),
+                expand = false,
+            )
+        }
+    }
+
+    private suspend fun refreshAppFileTreeDirectory(
+        directory: AppDataDirectory,
+        entry: AppFileEntry.Directory,
+        expand: Boolean,
+    ) {
+        val device = currentState.selectedDevice ?: return
+        val packageName = currentState.selectedApp?.packageName ?: return
+
+        update {
+            val tree = selectFileTree(directory)
+            updateFileTree(
+                directory = directory,
+                tree =
+                    tree.copy(
+                        expandedPaths = if (expand) tree.expandedPaths + entry.path else tree.expandedPaths,
+                        loadingPaths = tree.loadingPaths + entry.path,
+                        errorMessages = tree.errorMessages - entry.path,
+                    ),
+            )
+        }
+
+        val result = installedAppRepository.getAppFileChildren(device, entry)
+        if (currentState.selectedApp?.packageName != packageName) return
+
+        update {
+            val tree = selectFileTree(directory)
+            val nextTree =
+                if (result.isOk) {
+                    tree.copy(
+                        childrenByPath = tree.childrenByPath + (entry.path to result.value),
+                        loadingPaths = tree.loadingPaths - entry.path,
+                        errorMessages = tree.errorMessages - entry.path,
+                    )
+                } else {
+                    tree.copy(
+                        loadingPaths = tree.loadingPaths - entry.path,
+                        errorMessages =
+                            tree.errorMessages + (entry.path to (result.error.message ?: "Failed to load files")),
+                    )
+                }
+            updateFileTree(directory, nextTree)
+        }
     }
 
     private suspend fun refreshDataAppFileTree(
@@ -476,6 +724,81 @@ class AppStateHolder(
             loadAppFileTreeChildren(entry, selectTree, updateTree)
         }
     }
+
+    private fun AppState.selectFileTree(directory: AppDataDirectory): AppFileTreeState =
+        when (directory) {
+            AppDataDirectory.Data -> dataFileTree
+            AppDataDirectory.SdCardData -> sdCardDataFileTree
+        }
+
+    private fun AppState.updateFileTree(
+        directory: AppDataDirectory,
+        tree: AppFileTreeState,
+    ): AppState =
+        when (directory) {
+            AppDataDirectory.Data -> copy(dataFileTree = tree)
+            AppDataDirectory.SdCardData -> copy(sdCardDataFileTree = tree)
+        }
+
+    private fun AppState.selectedFile(directory: AppDataDirectory): AppFileEntry? =
+        when (directory) {
+            AppDataDirectory.Data -> selectedDataFile
+            AppDataDirectory.SdCardData -> selectedSdCardDataFile
+        }
+
+    private fun AppState.updateSelectedFile(
+        directory: AppDataDirectory,
+        selectedFile: AppFileEntry?,
+    ): AppState =
+        when (directory) {
+            AppDataDirectory.Data -> copy(selectedDataFile = selectedFile)
+            AppDataDirectory.SdCardData -> copy(selectedSdCardDataFile = selectedFile)
+        }
+
+    private fun AppState.clearAppFileSelection(
+        directory: AppDataDirectory,
+        entry: AppFileEntry,
+    ): AppState {
+        val nextSelectedFile =
+            selectedFile(directory)
+                ?.takeUnless { it.path.isSameOrChildPath(entry.path) }
+        val nextFilePreview =
+            filePreview
+                .takeUnless { it.entry?.path?.isSameOrChildPath(entry.path) == true }
+                ?: AppFilePreviewState()
+
+        return updateSelectedFile(directory, nextSelectedFile).copy(filePreview = nextFilePreview)
+    }
+
+    private fun AppFileEntry.withUpdatedSize(size: Long): AppFileEntry =
+        when (this) {
+            is AppFileEntry.Directory -> copy(size = size)
+            is AppFileEntry.File -> copy(size = size)
+            is AppFileEntry.Link -> copy(size = size)
+            is AppFileEntry.Other -> copy(size = size)
+        }
+
+    private fun AppFileEntry.parentPath(): String? =
+        path
+            .trimEnd('/')
+            .substringBeforeLast('/', missingDelimiterValue = "")
+            .takeIf { it.isNotBlank() }
+
+    private fun String.toDirectoryEntry(): AppFileEntry.Directory =
+        AppFileEntry.Directory(
+            name = substringAfterLast('/'),
+            path = this,
+            permissions = "",
+            size = 0L,
+            date = "",
+            time = "",
+        )
+
+    private fun InstalledApp.rootPath(directory: AppDataDirectory): String =
+        when (directory) {
+            AppDataDirectory.Data -> dataDir
+            AppDataDirectory.SdCardData -> sdCardDataDir
+        }
 
     private fun AppFileTreeState.clearDirectoryCache(path: String): AppFileTreeState =
         copy(

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppDetailPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppDetailPane.kt
@@ -35,6 +35,14 @@ fun AppDetailPane(
     onSelectSdCardDataFileNode: (AppFileEntry) -> Unit,
     onPreviewDataFileNode: (AppFileEntry) -> Unit,
     onPreviewSdCardDataFileNode: (AppFileEntry) -> Unit,
+    onUploadDataFileNode: (AppFileEntry) -> Unit,
+    onUploadSdCardDataFileNode: (AppFileEntry) -> Unit,
+    onDeleteDataFileNode: (AppFileEntry) -> Unit,
+    onDeleteSdCardDataFileNode: (AppFileEntry) -> Unit,
+    onRefreshDataFileNode: (AppFileEntry) -> Unit,
+    onRefreshSdCardDataFileNode: (AppFileEntry) -> Unit,
+    onRenameDataFileNode: (AppFileEntry) -> Unit,
+    onRenameSdCardDataFileNode: (AppFileEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (app == null) {
@@ -96,6 +104,10 @@ fun AppDetailPane(
                     selectedFile = selectedDataFile,
                     onSelectNode = onSelectDataFileNode,
                     onPreviewNode = onPreviewDataFileNode,
+                    onUploadNode = onUploadDataFileNode,
+                    onDeleteNode = onDeleteDataFileNode,
+                    onRefreshNode = onRefreshDataFileNode,
+                    onRenameNode = onRenameDataFileNode,
                 )
             }
 
@@ -109,6 +121,10 @@ fun AppDetailPane(
                     selectedFile = selectedSdCardDataFile,
                     onSelectNode = onSelectSdCardDataFileNode,
                     onPreviewNode = onPreviewSdCardDataFileNode,
+                    onUploadNode = onUploadSdCardDataFileNode,
+                    onDeleteNode = onDeleteSdCardDataFileNode,
+                    onRefreshNode = onRefreshSdCardDataFileNode,
+                    onRenameNode = onRenameSdCardDataFileNode,
                 )
             }
         }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeNode.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeNode.kt
@@ -1,6 +1,7 @@
 package jp.kaleidot725.adbpad.ui.screen.app.component.tree
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -27,6 +28,7 @@ import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.language.Language
 import jp.kaleidot725.adbpad.ui.common.resource.clickableBackground
 import jp.kaleidot725.adbpad.ui.component.indicator.RunningIndicator
+import jp.kaleidot725.adbpad.ui.component.menu.ThemedContextMenuArea
 import jp.kaleidot725.adbpad.ui.screen.app.component.formatAppFileSize
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFileTreeState
 
@@ -39,6 +41,10 @@ internal fun AppFileTreeNode(
     selectedFile: AppFileEntry?,
     onSelectNode: (AppFileEntry) -> Unit,
     onPreviewNode: (AppFileEntry) -> Unit,
+    onUploadNode: (AppFileEntry) -> Unit,
+    onDeleteNode: (AppFileEntry) -> Unit,
+    onRefreshNode: (AppFileEntry) -> Unit,
+    onRenameNode: (AppFileEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isExpanded = tree.expandedPaths.contains(entry.path)
@@ -48,68 +54,80 @@ internal fun AppFileTreeNode(
     val isSelected = selectedFile?.path == entry.path
 
     Column(modifier = modifier) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clickableBackground(
-                        isSelected = isSelected,
-                        shape = RoundedCornerShape(4.dp),
-                    ).combinedClickable(
-                        onClick = { onSelectNode(entry) },
-                        onDoubleClick = {
-                            if (entry.isDirectory) {
-                                onSelectNode(entry)
-                            } else {
-                                onPreviewNode(entry)
-                            }
-                        },
-                    )
-                    .padding(start = (depth * 16).dp, top = 4.dp, end = 4.dp, bottom = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ThemedContextMenuArea(
+            items = {
+                appFileTreeNodeContextMenuItems(
+                    entry = entry,
+                    onUploadNode = onUploadNode,
+                    onDeleteNode = onDeleteNode,
+                    onRefreshNode = onRefreshNode,
+                    onRenameNode = onRenameNode,
+                )
+            },
         ) {
-            AppFileTreeExpandIcon(
-                isDirectory = entry.isDirectory,
-                isExpanded = isExpanded,
-            )
-            Icon(
-                imageVector =
-                    when {
-                        entry.isDirectory && isExpanded -> Lucide.FolderOpen
-                        entry.isDirectory -> Lucide.Folder
-                        else -> Lucide.File
-                    },
-                contentDescription = null,
-                tint =
-                    if (entry.isDirectory) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                modifier = Modifier.size(18.dp),
-            )
-            Text(
-                text = entry.name,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f),
-            )
-            if (!entry.isDirectory) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickableBackground(
+                            isSelected = isSelected,
+                            shape = RoundedCornerShape(4.dp),
+                        ).combinedClickable(
+                            onClick = { onSelectNode(entry) },
+                            onDoubleClick = {
+                                if (entry.isDirectory) {
+                                    onSelectNode(entry)
+                                } else {
+                                    onPreviewNode(entry)
+                                }
+                            },
+                        )
+                        .padding(start = (depth * 16).dp, top = 4.dp, end = 4.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                AppFileTreeExpandIcon(
+                    isDirectory = entry.isDirectory,
+                    isExpanded = isExpanded,
+                )
+                Icon(
+                    imageVector =
+                        when {
+                            entry.isDirectory && isExpanded -> Lucide.FolderOpen
+                            entry.isDirectory -> Lucide.Folder
+                            else -> Lucide.File
+                        },
+                    contentDescription = null,
+                    tint =
+                        if (entry.isDirectory) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    modifier = Modifier.size(18.dp),
+                )
                 Text(
-                    text = formatAppFileSize(entry.size),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = entry.name,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
-            }
-            if (isLoading) {
-                RunningIndicator(
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(14.dp),
-                )
+                if (!entry.isDirectory) {
+                    Text(
+                        text = formatAppFileSize(entry.size),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                    )
+                }
+                if (isLoading) {
+                    RunningIndicator(
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
             }
         }
 
@@ -132,6 +150,10 @@ internal fun AppFileTreeNode(
                             selectedFile = selectedFile,
                             onSelectNode = onSelectNode,
                             onPreviewNode = onPreviewNode,
+                            onUploadNode = onUploadNode,
+                            onDeleteNode = onDeleteNode,
+                            onRefreshNode = onRefreshNode,
+                            onRenameNode = onRenameNode,
                         )
                     }
                 }
@@ -139,6 +161,20 @@ internal fun AppFileTreeNode(
         }
     }
 }
+
+private fun appFileTreeNodeContextMenuItems(
+    entry: AppFileEntry,
+    onUploadNode: (AppFileEntry) -> Unit,
+    onDeleteNode: (AppFileEntry) -> Unit,
+    onRefreshNode: (AppFileEntry) -> Unit,
+    onRenameNode: (AppFileEntry) -> Unit,
+): List<ContextMenuItem> =
+    listOf(
+        ContextMenuItem(label = Language.upload, onClick = { onUploadNode(entry) }),
+        ContextMenuItem(label = Language.delete, onClick = { onDeleteNode(entry) }),
+        ContextMenuItem(label = Language.tooltipRefresh, onClick = { onRefreshNode(entry) }),
+        ContextMenuItem(label = Language.rename, onClick = { onRenameNode(entry) }),
+    )
 
 @Preview
 @Composable
@@ -156,6 +192,10 @@ private fun AppFileTreeNodePreview() {
         selectedFile = directory,
         onSelectNode = {},
         onPreviewNode = {},
+        onUploadNode = {},
+        onDeleteNode = {},
+        onRefreshNode = {},
+        onRenameNode = {},
         modifier = Modifier.width(280.dp).padding(16.dp),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeView.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeView.kt
@@ -18,6 +18,10 @@ fun AppFileTreeView(
     selectedFile: AppFileEntry?,
     onSelectNode: (AppFileEntry) -> Unit,
     onPreviewNode: (AppFileEntry) -> Unit,
+    onUploadNode: (AppFileEntry) -> Unit,
+    onDeleteNode: (AppFileEntry) -> Unit,
+    onRefreshNode: (AppFileEntry) -> Unit,
+    onRenameNode: (AppFileEntry) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -34,6 +38,10 @@ fun AppFileTreeView(
                         selectedFile = selectedFile,
                         onSelectNode = onSelectNode,
                         onPreviewNode = onPreviewNode,
+                        onUploadNode = onUploadNode,
+                        onDeleteNode = onDeleteNode,
+                        onRefreshNode = onRefreshNode,
+                        onRenameNode = onRenameNode,
                     )
                 }
             }
@@ -56,6 +64,10 @@ private fun AppFileTreeViewPreview() {
         selectedFile = directory,
         onSelectNode = {},
         onPreviewNode = {},
+        onUploadNode = {},
+        onDeleteNode = {},
+        onRefreshNode = {},
+        onRenameNode = {},
         modifier = Modifier.width(280.dp).padding(16.dp),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
@@ -1,6 +1,7 @@
 package jp.kaleidot725.adbpad.ui.screen.app.state
 
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
+import jp.kaleidot725.adbpad.domain.model.app.AppDataDirectory
 import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.pulse.mvi.PulseAction
@@ -43,6 +44,26 @@ sealed class AppAction : PulseAction {
     ) : AppAction()
 
     data class PreviewSdCardDataFileNode(
+        val entry: AppFileEntry,
+    ) : AppAction()
+
+    data class UploadAppFileNode(
+        val directory: AppDataDirectory,
+        val entry: AppFileEntry,
+    ) : AppAction()
+
+    data class DeleteAppFileNode(
+        val directory: AppDataDirectory,
+        val entry: AppFileEntry,
+    ) : AppAction()
+
+    data class RefreshAppFileNode(
+        val directory: AppDataDirectory,
+        val entry: AppFileEntry,
+    ) : AppAction()
+
+    data class RenameAppFileNode(
+        val directory: AppDataDirectory,
         val entry: AppFileEntry,
     ) : AppAction()
 


### PR DESCRIPTION
## Summary
- Added right-click context menus to app file tree nodes for directories and files.
- Wired upload, delete, refresh, and rename actions through the app MVI flow for both data and SD card trees.
- Implemented ADB repository operations for push, rm, and mv, and added localized rename text.

## Testing
- `./gradlew compileKotlinJvm` passed.
- `./gradlew :runKtlintCheckOverJvmMainSourceSet` passed.
- `./gradlew ktlintCheck` was not fully green because of pre-existing `core/view` style violations unrelated to this change.