### PR TITLE
Update PulseMVI to 0.3.0 and adapt MVI generics

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ lucide = "1.1.0"
 coil = "3.4.0"
 zoomable = "2.11.1"
 scrcpy_kt = "1.9.0"
-pulse_mvi = "0.2.0"
+pulse_mvi = "0.3.0"
 
 [libraries]
 adam = { module = "com.malinskiy.adam:adam", version.ref = "adam" }

--- a/main/kotlin/jp/kaleidot725/adbpad/Main.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/Main.kt
@@ -17,7 +17,6 @@ import jp.kaleidot725.adbpad.ui.screen.command.CommandStateHolder
 import jp.kaleidot725.adbpad.ui.screen.device.DeviceSettingsScreen
 import jp.kaleidot725.adbpad.ui.screen.device.DeviceSettingsStateHolder
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsAction
-import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsSideEffect
 import jp.kaleidot725.adbpad.ui.screen.main.MainScreen
 import jp.kaleidot725.adbpad.ui.screen.main.MainStateHolder
 import jp.kaleidot725.adbpad.ui.screen.main.state.MainAction
@@ -27,7 +26,6 @@ import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotScreen
 import jp.kaleidot725.adbpad.ui.screen.screenshot.ScreenshotStateHolder
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingScreen
 import jp.kaleidot725.adbpad.ui.screen.setting.SettingStateHolder
-import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingSideEffect
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandScreen
 import jp.kaleidot725.adbpad.ui.screen.text.TextCommandStateHolder
 import jp.kaleidot725.adbpad.ui.section.top.TopSection
@@ -78,7 +76,7 @@ fun main() {
                 ),
             )
         }
-        PulseApp(appContainer) { _, onBroadcast ->
+        PulseApp(appContainer) { _, _ ->
             PulseContent(store = mainStateHolder) { state, onAction ->
                 if (state.size == WindowSize.UNKNOWN) return@PulseContent
                 if (state.isDark == null) return@PulseContent
@@ -94,7 +92,6 @@ fun main() {
                                     topState = topState,
                                     onTopAction = onTopAction,
                                     onOpenDeviceSettings = { device -> onAction(MainAction.OpenDeviceSettings(device)) },
-                                    onRefreshDevices = { onBroadcast(AppBroadCast.Refresh) },
                                     onToggleNavigationRail = { onAction(MainAction.ToggleNavigationRail) },
                                 )
                             },
@@ -165,33 +162,15 @@ fun main() {
                         )
                     },
                     settingContent = {
-                        PulseContent(
-                            store = settingStateHolder,
-                            onEvent = {
-                                when (it) {
-                                    SettingSideEffect.Saved -> {
-                                        onBroadcast(AppBroadCast.Refresh)
-                                    }
-                                }
-                            },
-                        ) { state, onAction ->
+                        PulseContent(store = settingStateHolder) { state, onAction ->
                             SettingScreen(
                                 state = state,
                                 onAction = onAction,
-                                onMainRefresh = { onBroadcast(AppBroadCast.Refresh) },
                             )
                         }
                     },
                     deviceSettingsContent = {
-                        PulseContent(
-                            store = deviceSettingsStateHolder,
-                            onEvent = {
-                                when (it) {
-                                    DeviceSettingsSideEffect.Saved -> onBroadcast(AppBroadCast.Refresh)
-                                    DeviceSettingsSideEffect.Cancelled -> onBroadcast(AppBroadCast.Refresh)
-                                }
-                            },
-                        ) { deviceSettingsState, onDeviceSettingsAction ->
+                        PulseContent(store = deviceSettingsStateHolder) { deviceSettingsState, onDeviceSettingsAction ->
                             deviceSettingsState.ifReady { device, deviceSettings ->
                                 DeviceSettingsScreen(
                                     device = device,

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppBroadCast.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppBroadCast.kt
@@ -7,4 +7,6 @@ sealed interface AppBroadCast : PulseBroadcast {
     data object Refresh : AppBroadCast
 }
 
-sealed interface AppUnicast : PulseUnicast
+sealed interface AppUnicast : PulseUnicast {
+    data object Refresh : AppUnicast
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppBroadCast.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppBroadCast.kt
@@ -1,7 +1,10 @@
 package jp.kaleidot725.adbpad.ui.container
 
 import jp.kaleidot725.pulse.mvi.PulseBroadcast
+import jp.kaleidot725.pulse.mvi.PulseUnicast
 
 sealed interface AppBroadCast : PulseBroadcast {
     data object Refresh : AppBroadCast
 }
+
+sealed interface AppUnicast : PulseUnicast

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppContainer.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppContainer.kt
@@ -4,5 +4,5 @@ import jp.kaleidot725.pulse.mvi.PulseContainer
 import jp.kaleidot725.pulse.mvi.PulseStore
 
 class AppContainer(
-    stores: List<PulseStore<*, *, *, AppBroadCast>>,
-) : PulseContainer<AppBroadCast>(stores = stores)
+    stores: List<PulseStore<*, *, *, AppBroadCast, AppUnicast>>,
+) : PulseContainer<AppBroadCast, AppUnicast>(stores = stores)

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppContainer.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/container/AppContainer.kt
@@ -5,4 +5,10 @@ import jp.kaleidot725.pulse.mvi.PulseStore
 
 class AppContainer(
     stores: List<PulseStore<*, *, *, AppBroadCast, AppUnicast>>,
-) : PulseContainer<AppBroadCast, AppUnicast>(stores = stores)
+) : PulseContainer<AppBroadCast, AppUnicast>(stores = stores) {
+    override fun onReceived(unicast: AppUnicast) {
+        when (unicast) {
+            AppUnicast.Refresh -> broadcast(AppBroadCast.Refresh)
+        }
+    }
+}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -9,6 +9,7 @@ import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.adbpad.domain.repository.InstalledAppRepository
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppAction
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFilePreviewState
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFileTreeState
@@ -32,7 +33,7 @@ import javax.swing.filechooser.FileNameExtensionFilter
 class AppStateHolder(
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
     private val installedAppRepository: InstalledAppRepository,
-) : PulseStore<AppState, AppAction, AppSideEffect, AppBroadCast>(
+) : PulseStore<AppState, AppAction, AppSideEffect, AppBroadCast, AppUnicast>(
         initialUiState = AppState(),
     ) {
     override fun onSetup() {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/command/CommandStateHolder.kt
@@ -8,6 +8,7 @@ import jp.kaleidot725.adbpad.domain.usecase.command.GetNormalCommandGroup
 import jp.kaleidot725.adbpad.domain.usecase.command.ToggleNormalCommandFavorite
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.command.model.CommandLayoutMode
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandAction
 import jp.kaleidot725.adbpad.ui.screen.command.state.CommandSideEffect
@@ -21,7 +22,7 @@ class CommandStateHolder(
     private val executeCommandUseCase: ExecuteCommandUseCase,
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
     private val normalCommandOutputRepository: NormalCommandOutputRepository,
-) : PulseStore<CommandState, CommandAction, CommandSideEffect, AppBroadCast>(initialUiState = CommandState()) {
+) : PulseStore<CommandState, CommandAction, CommandSideEffect, AppBroadCast, AppUnicast>(initialUiState = CommandState()) {
     override fun onSetup() {
         coroutineScope.launch {
             getSelectedDeviceFlowUseCase().collect {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
@@ -4,6 +4,7 @@ import jp.kaleidot725.adbpad.domain.model.device.DeviceSettings
 import jp.kaleidot725.adbpad.domain.repository.DeviceSettingsRepository
 import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsAction
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsSideEffect
@@ -15,7 +16,7 @@ import kotlinx.coroutines.launch
 class DeviceSettingsStateHolder(
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
     private val deviceSettingsRepository: DeviceSettingsRepository,
-) : PulseStore<DeviceSettingsState, DeviceSettingsAction, DeviceSettingsSideEffect, AppBroadCast>(
+) : PulseStore<DeviceSettingsState, DeviceSettingsAction, DeviceSettingsSideEffect, AppBroadCast, AppUnicast>(
         initialUiState = DeviceSettingsState(),
     ) {
     override fun onSetup() {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
@@ -65,7 +65,7 @@ class DeviceSettingsStateHolder(
 
             val success = deviceSettingsRepository.saveDeviceSettings(currentState.device, currentState.deviceSettings)
             if (success) {
-                event(DeviceSettingsSideEffect.Saved)
+                unicast(AppUnicast.Refresh)
             }
 
             update { copy(isSaving = false) }
@@ -73,7 +73,7 @@ class DeviceSettingsStateHolder(
     }
 
     private fun dismiss() {
-        event(DeviceSettingsSideEffect.Cancelled)
+        unicast(AppUnicast.Refresh)
     }
 
     private fun selectCategory(category: DeviceSettingCategory) {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/DeviceSettingsStateHolder.kt
@@ -7,7 +7,6 @@ import jp.kaleidot725.adbpad.ui.container.AppBroadCast
 import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.device.model.DeviceSettingCategory
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsAction
-import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsSideEffect
 import jp.kaleidot725.adbpad.ui.screen.device.state.DeviceSettingsState
 import jp.kaleidot725.pulse.mvi.PulseStore
 import kotlinx.coroutines.flow.firstOrNull
@@ -16,7 +15,7 @@ import kotlinx.coroutines.launch
 class DeviceSettingsStateHolder(
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
     private val deviceSettingsRepository: DeviceSettingsRepository,
-) : PulseStore<DeviceSettingsState, DeviceSettingsAction, DeviceSettingsSideEffect, AppBroadCast, AppUnicast>(
+) : PulseStore<DeviceSettingsState, DeviceSettingsAction, Nothing, AppBroadCast, AppUnicast>(
         initialUiState = DeviceSettingsState(),
     ) {
     override fun onSetup() {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/state/DeviceSettingsSideEffect.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/device/state/DeviceSettingsSideEffect.kt
@@ -1,9 +1,0 @@
-package jp.kaleidot725.adbpad.ui.screen.device.state
-
-import jp.kaleidot725.pulse.mvi.PulseEvent
-
-sealed class DeviceSettingsSideEffect : PulseEvent {
-    data object Saved : DeviceSettingsSideEffect()
-
-    data object Cancelled : DeviceSettingsSideEffect()
-}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainStateHolder.kt
@@ -13,6 +13,7 @@ import jp.kaleidot725.adbpad.domain.usecase.theme.GetDarkModeFlowUseCase
 import jp.kaleidot725.adbpad.domain.usecase.window.GetWindowSizeUseCase
 import jp.kaleidot725.adbpad.domain.usecase.window.SaveWindowSizeUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.main.state.MainAction
 import jp.kaleidot725.adbpad.ui.screen.main.state.MainDialog
 import jp.kaleidot725.adbpad.ui.screen.main.state.MainSideEffect
@@ -31,7 +32,7 @@ class MainStateHolder(
     private val getAccentColorUseCase: GetAccentColorUseCase,
     private val refreshUseCase: RefreshUseCase,
     private val shutdownAppUseCase: ShutdownAppUseCase,
-) : PulseStore<MainState, MainAction, MainSideEffect, AppBroadCast>(initialUiState = MainState()) {
+) : PulseStore<MainState, MainAction, MainSideEffect, AppBroadCast, AppUnicast>(initialUiState = MainState()) {
     override fun onSetup() {
         restoreWindowSize()
         startSyncDarkMode()

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/newdisplay/ScrcpyNewDisplayStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/newdisplay/ScrcpyNewDisplayStateHolder.kt
@@ -9,6 +9,7 @@ import jp.kaleidot725.adbpad.domain.usecase.scrcpy.GetScrcpyNewDisplayProfilesUs
 import jp.kaleidot725.adbpad.domain.usecase.scrcpy.LaunchScrcpyNewDisplayUseCase
 import jp.kaleidot725.adbpad.domain.usecase.scrcpy.SaveScrcpyNewDisplayProfileUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.newdisplay.state.ScrcpyNewDisplayAction
 import jp.kaleidot725.adbpad.ui.screen.newdisplay.state.ScrcpyNewDisplayFailureReason
 import jp.kaleidot725.adbpad.ui.screen.newdisplay.state.ScrcpyNewDisplayFeedback
@@ -25,7 +26,7 @@ class ScrcpyNewDisplayStateHolder(
     private val launchScrcpyNewDisplayUseCase: LaunchScrcpyNewDisplayUseCase,
     private val saveScrcpyNewDisplayProfileUseCase: SaveScrcpyNewDisplayProfileUseCase,
     private val deleteScrcpyNewDisplayProfileUseCase: DeleteScrcpyNewDisplayProfileUseCase,
-) : PulseStore<ScrcpyNewDisplayState, ScrcpyNewDisplayAction, ScrcpyNewDisplaySideEffect, AppBroadCast>(
+) : PulseStore<ScrcpyNewDisplayState, ScrcpyNewDisplayAction, ScrcpyNewDisplaySideEffect, AppBroadCast, AppUnicast>(
         initialUiState = ScrcpyNewDisplayState(),
     ) {
     override fun onSetup() {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/screenshot/ScreenshotStateHolder.kt
@@ -12,6 +12,7 @@ import jp.kaleidot725.adbpad.domain.usecase.screenshot.GetScreenshotCommandUseCa
 import jp.kaleidot725.adbpad.domain.usecase.screenshot.RenameScreenshotUseCase
 import jp.kaleidot725.adbpad.domain.usecase.screenshot.TakeScreenshotUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotAction
 import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotSideEffect
 import jp.kaleidot725.adbpad.ui.screen.screenshot.state.ScreenshotState
@@ -29,7 +30,7 @@ class ScreenshotStateHolder(
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
     private val screenshotCommandRepository: ScreenshotCommandRepository,
     private val renameScreenshotUseCase: RenameScreenshotUseCase,
-) : PulseStore<ScreenshotState, ScreenshotAction, ScreenshotSideEffect, AppBroadCast>(initialUiState = ScreenshotState()) {
+) : PulseStore<ScreenshotState, ScreenshotAction, ScreenshotSideEffect, AppBroadCast, AppUnicast>(initialUiState = ScreenshotState()) {
     override fun onSetup() {
         coroutineScope.launch {
             val commands = getScreenshotCommandUseCase()

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingScreen.kt
@@ -35,10 +35,9 @@ import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingState
 fun SettingScreen(
     state: SettingState,
     onAction: (SettingAction) -> Unit,
-    onMainRefresh: () -> Unit,
 ) {
     FloatingDialog(
-        onDismiss = onMainRefresh,
+        onDismiss = { onAction(SettingAction.Cancel) },
         modifier =
             Modifier
                 .width(960.dp)
@@ -123,7 +122,7 @@ fun SettingScreen(
                                 .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 12.dp),
                     ) {
                         Button(
-                            onClick = onMainRefresh,
+                            onClick = { onAction(SettingAction.Cancel) },
                             enabled = state.canCancel,
                         ) {
                             Text(

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
@@ -15,6 +15,7 @@ import jp.kaleidot725.adbpad.domain.usecase.scrcpy.SaveScrcpySettingsUseCase
 import jp.kaleidot725.adbpad.domain.usecase.sdkpath.GetSdkPathUseCase
 import jp.kaleidot725.adbpad.domain.usecase.sdkpath.SaveSdkPathUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingAction
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingSideEffect
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingState
@@ -33,7 +34,7 @@ class SettingStateHolder(
     private val restartAdbUseCase: RestartAdbUseCase,
     private val getAccentColorUseCase: GetAccentColorUseCase,
     private val saveAccentColorUseCase: SaveAccentColorUseCase,
-) : PulseStore<SettingState, SettingAction, SettingSideEffect, AppBroadCast>(initialUiState = SettingState()) {
+) : PulseStore<SettingState, SettingAction, SettingSideEffect, AppBroadCast, AppUnicast>(initialUiState = SettingState()) {
     private var oldAdbDirectoryPath: String = ""
     private var oldAdbPortNumber: Int = 0
 

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
@@ -70,6 +70,7 @@ class SettingStateHolder(
         coroutineScope.launch {
             when (uiAction) {
                 SettingAction.Save -> save()
+                SettingAction.Cancel -> dismiss()
                 is SettingAction.SelectCategory -> selectCategory(uiAction.category)
                 is SettingAction.UpdateAdbDirectoryPath -> updateAdbDirectoryPath(uiAction.value)
                 is SettingAction.UpdateAdbPortNumberPath -> updateAdbPortNumberPath(uiAction.value)
@@ -95,8 +96,12 @@ class SettingStateHolder(
         saveSdkPathUseCase(currentState.adbDirectoryPath, currentState.adbPortNumber.toIntOrNull())
         saveScrcpySettingsUseCase(currentState.scrcpyBinaryPath)
         restartAdbUseCase(oldAdbDirectory = oldAdbDirectoryPath, oldServerPort = oldAdbPortNumber)
-        event(SettingSideEffect.Saved)
+        unicast(AppUnicast.Refresh)
         update { this.copy(isSaving = false) }
+    }
+
+    private fun dismiss() {
+        unicast(AppUnicast.Refresh)
     }
 
     private fun updateLanguage(value: Language.Type) {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/SettingStateHolder.kt
@@ -17,7 +17,6 @@ import jp.kaleidot725.adbpad.domain.usecase.sdkpath.SaveSdkPathUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
 import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingAction
-import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingSideEffect
 import jp.kaleidot725.adbpad.ui.screen.setting.state.SettingState
 import jp.kaleidot725.pulse.mvi.PulseStore
 import kotlinx.coroutines.launch
@@ -34,7 +33,7 @@ class SettingStateHolder(
     private val restartAdbUseCase: RestartAdbUseCase,
     private val getAccentColorUseCase: GetAccentColorUseCase,
     private val saveAccentColorUseCase: SaveAccentColorUseCase,
-) : PulseStore<SettingState, SettingAction, SettingSideEffect, AppBroadCast, AppUnicast>(initialUiState = SettingState()) {
+) : PulseStore<SettingState, SettingAction, Nothing, AppBroadCast, AppUnicast>(initialUiState = SettingState()) {
     private var oldAdbDirectoryPath: String = ""
     private var oldAdbPortNumber: Int = 0
 

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingAction.kt
@@ -9,6 +9,8 @@ import jp.kaleidot725.adbpad.ui.screen.setting.model.SettingCategory
 sealed class SettingAction : PulseAction {
     data object Save : SettingAction()
 
+    data object Cancel : SettingAction()
+
     data class SelectCategory(
         val category: SettingCategory,
     ) : SettingAction()

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingSideEffect.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/setting/state/SettingSideEffect.kt
@@ -1,7 +1,0 @@
-package jp.kaleidot725.adbpad.ui.screen.setting.state
-
-import jp.kaleidot725.pulse.mvi.PulseEvent
-
-sealed class SettingSideEffect : PulseEvent {
-    data object Saved : SettingSideEffect()
-}

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/text/TextCommandStateHolder.kt
@@ -7,6 +7,7 @@ import jp.kaleidot725.adbpad.domain.usecase.device.GetSelectedDeviceFlowUseCase
 import jp.kaleidot725.adbpad.domain.usecase.text.ExecuteTextCommandUseCase
 import jp.kaleidot725.adbpad.domain.usecase.text.GetTextCommandUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.screen.text.state.TextCommandAction
 import jp.kaleidot725.adbpad.ui.screen.text.state.TextCommandSideEffect
 import jp.kaleidot725.adbpad.ui.screen.text.state.TextCommandState
@@ -18,7 +19,7 @@ class TextCommandStateHolder(
     private val getTextCommandUseCase: GetTextCommandUseCase,
     private val executeTextCommandUseCase: ExecuteTextCommandUseCase,
     private val getSelectedDeviceFlowUseCase: GetSelectedDeviceFlowUseCase,
-) : PulseStore<TextCommandState, TextCommandAction, TextCommandSideEffect, AppBroadCast>(initialUiState = TextCommandState()) {
+) : PulseStore<TextCommandState, TextCommandAction, TextCommandSideEffect, AppBroadCast, AppUnicast>(initialUiState = TextCommandState()) {
     override fun onSetup() {
         coroutineScope.launch {
             getSelectedDeviceFlowUseCase().collect {

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopSection.kt
@@ -70,7 +70,6 @@ fun TopSection(
     topState: TopState,
     onTopAction: (TopAction) -> Unit,
     onOpenDeviceSettings: (Device) -> Unit,
-    onRefreshDevices: () -> Unit,
     onToggleNavigationRail: () -> Unit,
 ) {
     Box(
@@ -102,7 +101,7 @@ fun TopSection(
                 TopSectionIconButton(
                     tooltip = Language.tooltipRefresh,
                     icon = Lucide.RefreshCcw,
-                    onClick = onRefreshDevices,
+                    onClick = { onTopAction(TopAction.Refresh) },
                     rotateOnPress = true,
                 )
 
@@ -304,7 +303,6 @@ private fun Preview() {
             ),
         onTopAction = {},
         onOpenDeviceSettings = {},
-        onRefreshDevices = {},
         onToggleNavigationRail = {},
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopStateHolder.kt
@@ -8,6 +8,7 @@ import jp.kaleidot725.adbpad.domain.usecase.device.SelectDeviceUseCase
 import jp.kaleidot725.adbpad.domain.usecase.device.UpdateDevicesUseCase
 import jp.kaleidot725.adbpad.domain.usecase.scrcpy.LaunchScrcpyUseCase
 import jp.kaleidot725.adbpad.ui.container.AppBroadCast
+import jp.kaleidot725.adbpad.ui.container.AppUnicast
 import jp.kaleidot725.adbpad.ui.section.top.state.TopAction
 import jp.kaleidot725.adbpad.ui.section.top.state.TopSideEffect
 import jp.kaleidot725.adbpad.ui.section.top.state.TopState
@@ -23,7 +24,7 @@ class TopStateHolder(
     private val selectDeviceUseCase: SelectDeviceUseCase,
     private val executeDeviceControlCommandUseCase: ExecuteDeviceControlCommandUseCase,
     private val launchScrcpyUseCase: LaunchScrcpyUseCase,
-) : PulseStore<TopState, TopAction, TopSideEffect, AppBroadCast>(TopState()) {
+) : PulseStore<TopState, TopAction, TopSideEffect, AppBroadCast, AppUnicast>(TopState()) {
     private var deviceJob: Job? = null
     private var selectedDeviceJob: Job? = null
 

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/TopStateHolder.kt
@@ -38,6 +38,7 @@ class TopStateHolder(
                 is TopAction.ExecuteCommand -> executeCommand(uiAction.command)
                 is TopAction.SelectDevice -> selectDevice(uiAction.device)
                 TopAction.LaunchScrcpy -> launchScrcpy()
+                TopAction.Refresh -> unicast(AppUnicast.Refresh)
             }
         }
     }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/state/TopAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/section/top/state/TopAction.kt
@@ -14,4 +14,6 @@ sealed class TopAction : PulseAction {
     ) : TopAction()
 
     data object LaunchScrcpy : TopAction()
+
+    data object Refresh : TopAction()
 }


### PR DESCRIPTION
## Summary
- Bump `PulseMVI` from `0.2.0` to `0.3.0`
- Add the new app-level `AppUnicast` type and thread it through `PulseContainer` and every `PulseStore`
- Update the MVI wiring so the project compiles against the 0.3.0 API

## Testing
- `./gradlew compileKotlinJvm`
- `./gradlew runKtlintCheckOverJvmMainSourceSet`
- `./gradlew ktlintCheck` was not clean due to existing ktlint violations in `core/view`, unrelated to this change