### PR TITLE
Use run-as for app private file access

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -29,6 +29,14 @@ kotlin {
         val jvmTest by getting {
             kotlin.srcDirs("test/kotlin")
             resources.srcDirs("test/resources")
+            dependencies {
+                implementation(libs.junit5)
+                runtimeOnly(libs.junit.platform.launcher)
+            }
         }
     }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
+++ b/core/data/main/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryImpl.kt
@@ -4,14 +4,16 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.malinskiy.adam.AndroidDebugBridgeClientFactory
+import com.malinskiy.adam.Const
+import com.malinskiy.adam.request.Feature
 import com.malinskiy.adam.request.device.FetchDeviceFeaturesRequest
 import com.malinskiy.adam.request.pkg.StreamingPackageInstallRequest
 import com.malinskiy.adam.request.shell.v1.ShellCommandRequest
-import com.malinskiy.adam.request.sync.AndroidFile
 import com.malinskiy.adam.request.sync.AndroidFileType
-import com.malinskiy.adam.request.sync.ListFilesRequest
 import com.malinskiy.adam.request.sync.PullRequest
 import com.malinskiy.adam.request.sync.PushRequest
+import com.malinskiy.adam.request.sync.compat.CompatListFileRequest
+import com.malinskiy.adam.request.sync.model.FileEntry
 import jp.kaleidot725.adbpad.domain.model.app.AppDataDirectory
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
@@ -23,8 +25,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.io.path.createTempFile
+import com.malinskiy.adam.request.shell.v2.ShellCommandRequest as ShellV2CommandRequest
 
 class InstalledAppRepositoryImpl : InstalledAppRepository {
     private val adbClient = AndroidDebugBridgeClientFactory().build()
@@ -91,8 +96,8 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
         withContext(Dispatchers.IO) {
             try {
                 val rootPath = getRootPath(app, directory)
-                val files = adbClient.execute(ListFilesRequest(rootPath), device.serial)
-                Ok(files.toAppFileEntries())
+                val files = listRemoteFiles(device, rootPath)
+                Ok(files)
             } catch (exception: Exception) {
                 if (exception is CancellationException) throw exception
                 Err(exception)
@@ -105,8 +110,8 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
     ): Result<List<AppFileEntry>, Exception> =
         withContext(Dispatchers.IO) {
             try {
-                val files = adbClient.execute(ListFilesRequest(directory.path), device.serial)
-                Ok(files.toAppFileEntries())
+                val files = listRemoteFiles(device, directory.path)
+                Ok(files)
             } catch (exception: Exception) {
                 if (exception is CancellationException) throw exception
                 Err(exception)
@@ -163,9 +168,14 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
             try {
                 if (!source.isFile) throw IOException("${source.name} is not a file")
 
-                val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
-                val isPushed = adbClient.execute(PushRequest(source, destination.path, supportedFeatures), device.serial)
-                if (!isPushed) throw IOException("Failed to overwrite ${destination.name}")
+                val privateDataPath = destination.path.toPrivateDataPath()
+                if (privateDataPath != null) {
+                    pushPrivateDataFile(device, source, privateDataPath, destination.name)
+                } else {
+                    val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+                    val isPushed = adbClient.execute(PushRequest(source, destination.path, supportedFeatures), device.serial)
+                    if (!isPushed) throw IOException("Failed to overwrite ${destination.name}")
+                }
                 Ok(Unit)
             } catch (exception: Exception) {
                 if (exception is CancellationException) throw exception
@@ -187,9 +197,14 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
                         is AppFileEntry.Directory -> destination.path.resolveChildPath(source.name)
                         else -> destination.path
                     }
-                val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
-                val isPushed = adbClient.execute(PushRequest(source, destinationPath, supportedFeatures), device.serial)
-                if (!isPushed) throw IOException("Failed to upload ${source.name}")
+                val privateDataPath = destinationPath.toPrivateDataPath()
+                if (privateDataPath != null) {
+                    pushPrivateDataFile(device, source, privateDataPath, source.name)
+                } else {
+                    val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+                    val isPushed = adbClient.execute(PushRequest(source, destinationPath, supportedFeatures), device.serial)
+                    if (!isPushed) throw IOException("Failed to upload ${source.name}")
+                }
                 Ok(Unit)
             } catch (exception: Exception) {
                 if (exception is CancellationException) throw exception
@@ -203,16 +218,29 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
     ): Result<Unit, Exception> =
         withContext(Dispatchers.IO) {
             try {
-                val command =
+                val commandPrefix =
                     if (entry is AppFileEntry.Directory) {
-                        "rm -rf ${entry.path.toShellArgument()}"
+                        "rm -rf"
                     } else {
-                        "rm -f ${entry.path.toShellArgument()}"
+                        "rm -f"
                     }
-                val result = adbClient.execute(ShellCommandRequest(command), device.serial)
-                if (result.exitCode != 0) {
-                    throw IOException(result.output.ifBlank { "Failed to delete ${entry.name}" })
-                }
+                val privateDataPath = entry.path.toPrivateDataPath()
+                val result =
+                    if (privateDataPath != null) {
+                        executeRunAsCommand(
+                            device = device,
+                            packageName = privateDataPath.packageName,
+                            command = "$commandPrefix ${privateDataPath.relativePath.toShellArgument()}",
+                        )
+                    } else {
+                        adbClient
+                            .execute(
+                                ShellCommandRequest("$commandPrefix ${entry.path.toShellArgument()}"),
+                                device.serial,
+                            ).toShellOutput()
+                    }
+
+                if (result.exitCode != 0) throw IOException(result.errorMessage("Failed to delete ${entry.name}"))
                 Ok(Unit)
             } catch (exception: Exception) {
                 if (exception is CancellationException) throw exception
@@ -234,10 +262,70 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
 
                 val parentPath = entry.parentPath() ?: throw IOException("Cannot rename ${entry.name}")
                 val destinationPath = parentPath.resolveChildPath(normalizedName)
-                val command = "mv ${entry.path.toShellArgument()} ${destinationPath.toShellArgument()}"
-                val result = adbClient.execute(ShellCommandRequest(command), device.serial)
+                val sourcePrivateDataPath = entry.path.toPrivateDataPath()
+                val destinationPrivateDataPath = destinationPath.toPrivateDataPath()
+                val result =
+                    if (sourcePrivateDataPath != null) {
+                        if (
+                            destinationPrivateDataPath == null ||
+                            sourcePrivateDataPath.packageName != destinationPrivateDataPath.packageName
+                        ) {
+                            throw IOException("Cannot rename ${entry.name}")
+                        }
+
+                        executeRunAsCommand(
+                            device = device,
+                            packageName = sourcePrivateDataPath.packageName,
+                            command =
+                                "mv ${sourcePrivateDataPath.relativePath.toShellArgument()} " +
+                                    destinationPrivateDataPath.relativePath.toShellArgument(),
+                        )
+                    } else {
+                        adbClient
+                            .execute(
+                                ShellCommandRequest(
+                                    "mv ${entry.path.toShellArgument()} " +
+                                        destinationPath.toShellArgument(),
+                                ),
+                                device.serial,
+                            ).toShellOutput()
+                    }
+
+                if (result.exitCode != 0) throw IOException(result.errorMessage("Failed to rename ${entry.name}"))
+                Ok(Unit)
+            } catch (exception: Exception) {
+                if (exception is CancellationException) throw exception
+                Err(exception)
+            }
+        }
+
+    override suspend fun createAppDirectory(
+        device: Device,
+        parent: AppFileEntry.Directory,
+        name: String,
+    ): Result<Unit, Exception> =
+        withContext(Dispatchers.IO) {
+            try {
+                val directoryName = AppFileOperationCommand.normalizeFileName(name)
+                val directoryPath = parent.path.resolveChildPath(directoryName)
+                val privateDataPath = directoryPath.toPrivateDataPath()
+                val result =
+                    if (privateDataPath != null) {
+                        executeRunAsCommand(
+                            device = device,
+                            packageName = privateDataPath.packageName,
+                            command = AppFileOperationCommand.mkdirCommand(privateDataPath.relativePath),
+                        )
+                    } else {
+                        adbClient
+                            .execute(
+                                ShellCommandRequest(AppFileOperationCommand.mkdirCommand(directoryPath)),
+                                device.serial,
+                            ).toShellOutput()
+                    }
+
                 if (result.exitCode != 0) {
-                    throw IOException(result.output.ifBlank { "Failed to rename ${entry.name}" })
+                    throw IOException(result.errorMessage("Failed to create $directoryName"))
                 }
                 Ok(Unit)
             } catch (exception: Exception) {
@@ -260,9 +348,62 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
         entry: AppFileEntry.File,
         localFile: File,
     ) {
+        val privateDataPath = entry.path.toPrivateDataPath()
+        if (privateDataPath != null) {
+            pullPrivateDataFile(device, privateDataPath, entry, localFile)
+            return
+        }
+
         val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
         val isPulled = adbClient.execute(PullRequest(entry.path, localFile, supportedFeatures), device.serial)
         if (!isPulled) throw IOException("Failed to load ${entry.name}")
+    }
+
+    private suspend fun pullPrivateDataFile(
+        device: Device,
+        privateDataPath: PrivateDataPath,
+        entry: AppFileEntry.File,
+        localFile: File,
+    ) {
+        val result =
+            executeRunAsCommand(
+                device = device,
+                packageName = privateDataPath.packageName,
+                command = "cat ${privateDataPath.relativePath.toShellArgument()}",
+                requireShellV2 = true,
+            )
+        if (result.exitCode != 0) throw IOException(result.errorMessage("Failed to load ${entry.name}"))
+        localFile.outputStream().use { it.write(result.stdout) }
+    }
+
+    private suspend fun pushPrivateDataFile(
+        device: Device,
+        source: File,
+        privateDataPath: PrivateDataPath,
+        targetName: String,
+    ) {
+        val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+        val remoteTempFile = "/data/local/tmp/adbpad-${System.nanoTime()}-${source.name.toSafeRemoteFileName()}"
+        try {
+            val isPushed =
+                adbClient.execute(
+                    PushRequest(source, remoteTempFile, supportedFeatures, mode = "0644"),
+                    device.serial,
+                )
+            if (!isPushed) throw IOException("Failed to upload ${source.name}")
+
+            val result =
+                executeRunAsCommand(
+                    device = device,
+                    packageName = privateDataPath.packageName,
+                    command =
+                        "cp ${remoteTempFile.toShellArgument()} " +
+                            privateDataPath.relativePath.toShellArgument(),
+                )
+            if (result.exitCode != 0) throw IOException(result.errorMessage("Failed to upload $targetName"))
+        } finally {
+            adbClient.execute(ShellCommandRequest("rm -f ${remoteTempFile.toShellArgument()}"), device.serial)
+        }
     }
 
     private fun createPreviewFile(entry: AppFileEntry.File): File {
@@ -295,6 +436,28 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
             AppDataDirectory.SdCardData -> app.sdCardDataDir
         }
 
+    private suspend fun listRemoteFiles(
+        device: Device,
+        directory: String,
+    ): List<AppFileEntry> {
+        val privateDataPath = directory.toPrivateDataPath()
+        if (privateDataPath != null) {
+            val result =
+                executeRunAsCommand(
+                    device = device,
+                    packageName = privateDataPath.packageName,
+                    command = "ls -la ${privateDataPath.relativePath.toShellArgument()}",
+                )
+            if (result.exitCode != 0) throw IOException(result.errorMessage("Failed to load $directory"))
+            return result.output.toAppFileEntriesFromLs(directory)
+        }
+
+        val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+        return adbClient
+            .execute(CompatListFileRequest(directory, supportedFeatures), device.serial)
+            .let { it.toAppFileEntries(directory) }
+    }
+
     private fun String.toInstalledApp(): InstalledApp? {
         val line = trim()
         if (!line.startsWith(PACKAGE_PREFIX)) return null
@@ -302,78 +465,56 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
         return InstalledApp(packageName = line.removePrefix(PACKAGE_PREFIX))
     }
 
-    private fun List<AndroidFile>.toAppFileEntries(): List<AppFileEntry> =
-        asSequence()
-            .filterNot { it.name == "." || it.name == ".." }
-            .map { it.toAppFileEntry() }
-            .sortedWith(
-                compareByDescending<AppFileEntry> { it.isDirectory }
-                    .thenBy { it.name.lowercase(Locale.getDefault()) },
-            ).toList()
-
-    private fun AndroidFile.toAppFileEntry(): AppFileEntry {
-        val path = directory.resolveChildPath(name)
-        return when (type) {
-            AndroidFileType.DIRECTORY -> {
-                AppFileEntry.Directory(
-                    name = name,
-                    path = path,
-                    permissions = permissions,
-                    size = size,
-                    date = date,
-                    time = time,
-                )
-            }
-
-            AndroidFileType.REGULAR_FILE -> {
-                AppFileEntry.File(
-                    name = name,
-                    path = path,
-                    permissions = permissions,
-                    size = size,
-                    date = date,
-                    time = time,
-                )
-            }
-
-            AndroidFileType.SYMBOLIC_LINK -> {
-                AppFileEntry.Link(
-                    name = name,
-                    path = path,
-                    permissions = permissions,
-                    size = size,
-                    date = date,
-                    time = time,
-                )
-            }
-
-            else -> {
-                AppFileEntry.Other(
-                    name = name,
-                    path = path,
-                    permissions = permissions,
-                    size = size,
-                    date = date,
-                    time = time,
-                )
-            }
+    private suspend fun executeRunAsCommand(
+        device: Device,
+        packageName: String,
+        command: String,
+        requireShellV2: Boolean = false,
+    ): ShellOutput {
+        val shellCommand = "run-as ${packageName.toShellArgument()} $command"
+        val supportedFeatures = adbClient.execute(FetchDeviceFeaturesRequest(device.serial), device.serial)
+        return if (supportedFeatures.contains(Feature.SHELL_V2)) {
+            adbClient.execute(ShellV2CommandRequest(shellCommand), device.serial).toShellOutput()
+        } else {
+            if (requireShellV2) throw IOException("run-as file transfer requires shell v2")
+            adbClient.execute(ShellCommandRequest(shellCommand), device.serial).toShellOutput()
         }
     }
 
-    private fun String.resolveChildPath(name: String): String =
-        if (endsWith("/")) {
-            "$this$name"
-        } else {
-            "$this/$name"
-        }
+    private fun ShellOutput.errorMessage(fallback: String): String =
+        errorOutput
+            .trim()
+            .ifBlank { output.trim() }
+            .ifBlank { fallback }
+
+    private fun com.malinskiy.adam.request.shell.v1.ShellCommandResult.toShellOutput(): ShellOutput =
+        ShellOutput(
+            stdout = stdout,
+            output = output,
+            errorOutput = "",
+            exitCode = exitCode,
+        )
+
+    private fun com.malinskiy.adam.request.shell.v2.ShellCommandResult.toShellOutput(): ShellOutput =
+        ShellOutput(
+            stdout = stdout,
+            output = output,
+            errorOutput = errorOutput,
+            exitCode = exitCode,
+        )
+
+    private data class ShellOutput(
+        val stdout: ByteArray,
+        val output: String,
+        val errorOutput: String,
+        val exitCode: Int,
+    )
 
     private fun AppFileEntry.parentPath(): String? =
         path
             .trimEnd('/')
             .substringBeforeLast('/', missingDelimiterValue = "")
             .takeIf { it.isNotBlank() }
-
-    private fun String.toShellArgument(): String = "'${replace("'", "'\"'\"'")}'"
 
     private fun AppFileEntry.File.isImageFile(): Boolean = extension() in IMAGE_FILE_EXTENSIONS
 
@@ -418,3 +559,257 @@ class InstalledAppRepositoryImpl : InstalledAppRepository {
         private val TEXT_FILE_NAMES = setOf("changelog", "license", "notice", "readme")
     }
 }
+
+internal object AppFileOperationCommand {
+    fun normalizeFileName(name: String): String {
+        val normalizedName = name.trim()
+        if (normalizedName.isBlank() || normalizedName.contains("/")) {
+            throw IOException("Invalid name")
+        }
+        return normalizedName
+    }
+
+    fun mkdirCommand(path: String): String = "mkdir -p ${path.toShellArgument()}"
+}
+
+internal fun String.toPrivateDataPath(): PrivateDataPath? {
+    if (!startsWith(DATA_DIRECTORY_PREFIX)) return null
+
+    val withoutPrefix = removePrefix(DATA_DIRECTORY_PREFIX)
+    val packageName = withoutPrefix.substringBefore('/').takeIf { it.isNotBlank() } ?: return null
+    val relativePath =
+        withoutPrefix
+            .substringAfter('/', missingDelimiterValue = ".")
+            .ifBlank { "." }
+
+    return PrivateDataPath(
+        packageName = packageName,
+        relativePath = relativePath,
+    )
+}
+
+internal fun String.toAppFileEntriesFromLs(directory: String): List<AppFileEntry> =
+    lineSequence()
+        .mapNotNull { it.toAppFileEntryFromLs(directory) }
+        .filterNot { it.name == "." || it.name == ".." }
+        .sortedWith(appFileEntryComparator())
+        .toList()
+
+internal fun List<FileEntry>.toAppFileEntries(directory: String): List<AppFileEntry> =
+    asSequence()
+        .filter { it.exists() }
+        .filterNot { it.name == "." || it.name == ".." || it.name == null }
+        .map { it.toAppFileEntry(directory) }
+        .sortedWith(appFileEntryComparator())
+        .toList()
+
+internal fun String.toShellArgument(): String = "'${replace("'", "'\\''")}'"
+
+internal fun String.toSafeRemoteFileName(): String =
+    replace(REMOTE_FILE_NAME_REGEX, "_")
+        .ifBlank { "file" }
+
+internal fun String.resolveChildPath(name: String): String =
+    if (endsWith("/")) {
+        "$this$name"
+    } else {
+        "$this/$name"
+    }
+
+internal data class PrivateDataPath(
+    val packageName: String,
+    val relativePath: String,
+)
+
+private fun String.toAppFileEntryFromLs(directory: String): AppFileEntry? {
+    val match = LS_LINE_REGEX.matchEntire(trim()) ?: return null
+    val permissions = match.groupValues[1]
+    val size = match.groupValues[4].filter { it.isDigit() }.toLongOrNull() ?: 0L
+    val date = match.groupValues[5]
+    val time = match.groupValues[6]
+    var name = match.groupValues[7]
+    val type = permissions.firstOrNull().toAndroidFileType()
+
+    if (type == AndroidFileType.SYMBOLIC_LINK) {
+        name = name.substringBefore(" -> ").trim()
+    }
+
+    return toAppFileEntry(
+        type = type,
+        name = name,
+        path = directory.resolveChildPath(name),
+        permissions = permissions,
+        size = size,
+        date = date,
+        time = time,
+    )
+}
+
+private fun FileEntry.toAppFileEntry(directory: String): AppFileEntry {
+    val name = requireNotNull(name)
+    val path = directory.resolveChildPath(name)
+    val dateTime = mtime.atZone(FILE_TIME_ZONE)
+    return toAppFileEntry(
+        type = type,
+        name = name,
+        path = path,
+        permissions = mode.toPermissionString(),
+        size = size().toLong(),
+        date = FILE_DATE_FORMATTER.format(dateTime),
+        time = FILE_TIME_FORMATTER.format(dateTime),
+    )
+}
+
+private fun toAppFileEntry(
+    type: AndroidFileType,
+    name: String,
+    path: String,
+    permissions: String,
+    size: Long,
+    date: String,
+    time: String,
+): AppFileEntry =
+    when (type) {
+        AndroidFileType.DIRECTORY -> {
+            AppFileEntry.Directory(
+                name = name,
+                path = path,
+                permissions = permissions,
+                size = size,
+                date = date,
+                time = time,
+            )
+        }
+
+        AndroidFileType.REGULAR_FILE -> {
+            AppFileEntry.File(
+                name = name,
+                path = path,
+                permissions = permissions,
+                size = size,
+                date = date,
+                time = time,
+            )
+        }
+
+        AndroidFileType.SYMBOLIC_LINK -> {
+            AppFileEntry.Link(
+                name = name,
+                path = path,
+                permissions = permissions,
+                size = size,
+                date = date,
+                time = time,
+            )
+        }
+
+        else -> {
+            AppFileEntry.Other(
+                name = name,
+                path = path,
+                permissions = permissions,
+                size = size,
+                date = date,
+                time = time,
+            )
+        }
+    }
+
+private val FileEntry.type: AndroidFileType
+    get() =
+        when {
+            isDirectory() -> AndroidFileType.DIRECTORY
+            isRegularFile() -> AndroidFileType.REGULAR_FILE
+            isBlockDevice() -> AndroidFileType.BLOCK_SPECIAL_FILE
+            isCharDevice() -> AndroidFileType.CHARACTER_SPECIAL_FILE
+            isLink() -> AndroidFileType.SYMBOLIC_LINK
+            mode.hasFileType(Const.FileType.S_IFIFO) -> AndroidFileType.FIFO
+            mode.hasFileType(Const.FileType.S_IFSOCK) -> AndroidFileType.SOCKET_LINK
+            else -> AndroidFileType.OTHER
+        }
+
+private fun UInt.hasFileType(fileType: UInt): Boolean = (this and Const.FileType.S_IFMT) == fileType
+
+private fun Char?.toAndroidFileType(): AndroidFileType =
+    when (this) {
+        '-' -> AndroidFileType.REGULAR_FILE
+        'b' -> AndroidFileType.BLOCK_SPECIAL_FILE
+        'c' -> AndroidFileType.CHARACTER_SPECIAL_FILE
+        'd' -> AndroidFileType.DIRECTORY
+        'l' -> AndroidFileType.SYMBOLIC_LINK
+        'p' -> AndroidFileType.FIFO
+        's' -> AndroidFileType.SOCKET_LINK
+        else -> AndroidFileType.OTHER
+    }
+
+private fun UInt.toPermissionString(): String {
+    val mode = toInt()
+    return buildString {
+        append(mode.toFileTypeChar())
+        appendReadWriteExecute(mode, OWNER_READ, OWNER_WRITE, OWNER_EXECUTE, SET_UID, 's', 'S')
+        appendReadWriteExecute(mode, GROUP_READ, GROUP_WRITE, GROUP_EXECUTE, SET_GID, 's', 'S')
+        appendReadWriteExecute(mode, OTHER_READ, OTHER_WRITE, OTHER_EXECUTE, STICKY, 't', 'T')
+    }
+}
+
+private fun StringBuilder.appendReadWriteExecute(
+    mode: Int,
+    readMask: Int,
+    writeMask: Int,
+    executeMask: Int,
+    specialMask: Int,
+    specialExecuteChar: Char,
+    specialOnlyChar: Char,
+) {
+    append(if (mode hasMode readMask) 'r' else '-')
+    append(if (mode hasMode writeMask) 'w' else '-')
+    append(
+        when {
+            mode hasMode specialMask -> if (mode hasMode executeMask) specialExecuteChar else specialOnlyChar
+            mode hasMode executeMask -> 'x'
+            else -> '-'
+        },
+    )
+}
+
+private fun Int.toFileTypeChar(): Char =
+    when (toUInt() and Const.FileType.S_IFMT) {
+        Const.FileType.S_IFDIR -> 'd'
+        Const.FileType.S_IFREG -> '-'
+        Const.FileType.S_IFBLK -> 'b'
+        Const.FileType.S_IFCHR -> 'c'
+        Const.FileType.S_IFLNK -> 'l'
+        Const.FileType.S_IFIFO -> 'p'
+        Const.FileType.S_IFSOCK -> 's'
+        else -> '?'
+    }
+
+private infix fun Int.hasMode(mask: Int): Boolean = this and mask != 0
+
+private fun appFileEntryComparator(): Comparator<AppFileEntry> =
+    compareByDescending<AppFileEntry> { it.isDirectory }
+        .thenBy { it.name.lowercase(Locale.getDefault()) }
+
+private const val DATA_DIRECTORY_PREFIX = "/data/data/"
+private const val OWNER_READ = 0x100
+private const val OWNER_WRITE = 0x80
+private const val OWNER_EXECUTE = 0x40
+private const val GROUP_READ = 0x20
+private const val GROUP_WRITE = 0x10
+private const val GROUP_EXECUTE = 0x8
+private const val OTHER_READ = 0x4
+private const val OTHER_WRITE = 0x2
+private const val OTHER_EXECUTE = 0x1
+private const val SET_UID = 0x800
+private const val SET_GID = 0x400
+private const val STICKY = 0x200
+private val FILE_TIME_ZONE = ZoneId.systemDefault()
+private val FILE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+private val FILE_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm")
+private val REMOTE_FILE_NAME_REGEX = Regex("[^A-Za-z0-9._-]")
+private val LS_LINE_REGEX =
+    Regex(
+        "^([bcdlsp-][-r][-w][-xsS][-r][-w][-xsS][-r][-w][-xstST])\\s+" +
+            "(?:\\d+\\s+)?(\\S+)\\s+(\\S+)\\s+([\\d\\s,]*)\\s+" +
+            "(\\d{4}-\\d\\d-\\d\\d)\\s+(\\d\\d:\\d\\d)\\s+(.*)$",
+    )

--- a/core/data/test/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryFileConversionTest.kt
+++ b/core/data/test/kotlin/jp/kaleidot725/adbpad/data/repository/InstalledAppRepositoryFileConversionTest.kt
@@ -1,0 +1,133 @@
+package jp.kaleidot725.adbpad.data.repository
+
+import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class InstalledAppRepositoryFileConversionTest {
+    @Test
+    fun `toPrivateDataPath converts data root to package and dot relative path`() {
+        val result = "/data/data/com.example.app".toPrivateDataPath()
+
+        assertEquals("com.example.app", result?.packageName)
+        assertEquals(".", result?.relativePath)
+    }
+
+    @Test
+    fun `toPrivateDataPath converts data child path to package and relative path`() {
+        val result = "/data/data/com.example.app/shared_prefs/settings.xml".toPrivateDataPath()
+
+        assertEquals("com.example.app", result?.packageName)
+        assertEquals("shared_prefs/settings.xml", result?.relativePath)
+    }
+
+    @Test
+    fun `toPrivateDataPath ignores sdcard path`() {
+        val result = "/sdcard/Android/data/com.example.app/files".toPrivateDataPath()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `toAppFileEntriesFromLs converts directory output to app file entries`() {
+        val result =
+            """
+            total 12
+            drwx------ 3 u0_a123 u0_a123 4096 2026-05-29 10:00 .
+            drwx------ 10 u0_a123 u0_a123 4096 2026-05-29 09:59 ..
+            drwxrwx--x 2 u0_a123 u0_a123 4096 2026-05-29 10:01 files
+            -rw-rw---- 1 u0_a123 u0_a123 128 2026-05-29 10:02 settings.xml
+            lrwxrwxrwx 1 u0_a123 u0_a123 11 2026-05-29 10:03 current -> files/cache
+            -rw-rw---- 1 u0_a123 u0_a123 256 2026-05-29 10:04 file with spaces.txt
+            """.trimIndent()
+                .toAppFileEntriesFromLs(directory = "/data/data/com.example.app")
+
+        assertEquals(
+            listOf(
+                AppFileEntry.Directory(
+                    name = "files",
+                    path = "/data/data/com.example.app/files",
+                    permissions = "drwxrwx--x",
+                    size = 4096,
+                    date = "2026-05-29",
+                    time = "10:01",
+                ),
+                AppFileEntry.Link(
+                    name = "current",
+                    path = "/data/data/com.example.app/current",
+                    permissions = "lrwxrwxrwx",
+                    size = 11,
+                    date = "2026-05-29",
+                    time = "10:03",
+                ),
+                AppFileEntry.File(
+                    name = "file with spaces.txt",
+                    path = "/data/data/com.example.app/file with spaces.txt",
+                    permissions = "-rw-rw----",
+                    size = 256,
+                    date = "2026-05-29",
+                    time = "10:04",
+                ),
+                AppFileEntry.File(
+                    name = "settings.xml",
+                    path = "/data/data/com.example.app/settings.xml",
+                    permissions = "-rw-rw----",
+                    size = 128,
+                    date = "2026-05-29",
+                    time = "10:02",
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toAppFileEntriesFromLs resolves nested directory child paths`() {
+        val result =
+            "-rw-rw---- 1 u0_a123 u0_a123 64 2026-05-29 10:05 cache.db"
+                .toAppFileEntriesFromLs(directory = "/data/data/com.example.app/files")
+
+        val entry = assertInstanceOf(AppFileEntry.File::class.java, result.single())
+        assertEquals("cache.db", entry.name)
+        assertEquals("/data/data/com.example.app/files/cache.db", entry.path)
+    }
+
+    @Test
+    fun `toShellArgument escapes single quotes`() {
+        val result = "shared_prefs/user's settings.xml".toShellArgument()
+
+        assertEquals("'shared_prefs/user'\\''s settings.xml'", result)
+    }
+
+    @Test
+    fun `toSafeRemoteFileName keeps shell temp file names safe`() {
+        val result = "user settings #1.xml".toSafeRemoteFileName()
+
+        assertEquals("user_settings__1.xml", result)
+    }
+
+    @Test
+    fun `normalizeFileName trims valid directory names`() {
+        val result = AppFileOperationCommand.normalizeFileName("  cache  ")
+
+        assertEquals("cache", result)
+    }
+
+    @Test
+    fun `normalizeFileName rejects nested directory names`() {
+        assertThrows(IOException::class.java) {
+            AppFileOperationCommand.normalizeFileName("files/cache")
+        }
+    }
+
+    @Test
+    fun `mkdirCommand creates parents and quotes path`() {
+        val result = AppFileOperationCommand.mkdirCommand("/sdcard/Android/data/com.example.app/user's cache")
+
+        assertEquals("mkdir -p '/sdcard/Android/data/com.example.app/user'\\''s cache'", result)
+    }
+}

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/Language.kt
@@ -33,6 +33,8 @@ object Language : StringResources {
         get() = getCurrentResources().download
     override val rename: String
         get() = getCurrentResources().rename
+    override val createDirectory: String
+        get() = getCurrentResources().createDirectory
     override val send: String
         get() = getCurrentResources().send
     override val cancel: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/ChineseResources.kt
@@ -15,6 +15,7 @@ object ChineseResources : StringResources {
     override val upload = "上传"
     override val download = "下载"
     override val rename = "重命名"
+    override val createDirectory = "创建目录"
     override val tab = "标签"
     override val send = "发送"
     override val cancel = "取消"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/EnglishResources.kt
@@ -15,6 +15,7 @@ object EnglishResources : StringResources {
     override val upload = "Upload"
     override val download = "Download"
     override val rename = "Rename"
+    override val createDirectory = "Create directory"
     override val tab = "Tab"
     override val send = "Send"
     override val cancel = "Cancel"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/JapaneseResources.kt
@@ -15,6 +15,7 @@ object JapaneseResources : StringResources {
     override val upload = "アップロード"
     override val download = "ダウンロード"
     override val rename = "名称を変更"
+    override val createDirectory = "ディレクトリを作成"
     override val tab = "Tab"
     override val send = "送信"
     override val cancel = "キャンセル"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/StringResources.kt
@@ -14,6 +14,7 @@ interface StringResources {
     val upload: String
     val download: String
     val rename: String
+    val createDirectory: String
     val tab: String
     val send: String
     val cancel: String

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/model/language/resources/TurkishResources.kt
@@ -15,6 +15,7 @@ object TurkishResources : StringResources {
     override val upload = "Karşıya yükle"
     override val download = "İndir"
     override val rename = "Yeniden adlandır"
+    override val createDirectory = "Dizin oluştur"
     override val tab = "Sekme"
     override val send = "Gönder"
     override val cancel = "İptal"

--- a/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
+++ b/core/domain/main/kotlin/jp/kaleidot725/adbpad/domain/repository/InstalledAppRepository.kt
@@ -65,4 +65,10 @@ interface InstalledAppRepository {
         entry: AppFileEntry,
         name: String,
     ): Result<Unit, Exception>
+
+    suspend fun createAppDirectory(
+        device: Device,
+        parent: AppFileEntry.Directory,
+        name: String,
+    ): Result<Unit, Exception>
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-
 kotlin_serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin_serialization" }
 kotlin-result = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlin_result" }
 junit5 = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 koin = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 jSystemThemeDetectorVer = { module = "com.github.Dansoftowner:jSystemThemeDetector", version.ref = "system_theme_detector" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppScreen.kt
@@ -85,6 +85,12 @@ fun AppScreen(
                 onRefreshSdCardDataFileNode = { onAction(AppAction.RefreshAppFileNode(AppDataDirectory.SdCardData, it)) },
                 onRenameDataFileNode = { onAction(AppAction.RenameAppFileNode(AppDataDirectory.Data, it)) },
                 onRenameSdCardDataFileNode = { onAction(AppAction.RenameAppFileNode(AppDataDirectory.SdCardData, it)) },
+                onCreateDataFileDirectoryNode = {
+                    onAction(AppAction.CreateAppDirectoryNode(AppDataDirectory.Data, it))
+                },
+                onCreateSdCardDataFileDirectoryNode = {
+                    onAction(AppAction.CreateAppDirectoryNode(AppDataDirectory.SdCardData, it))
+                },
                 modifier = Modifier.fillMaxSize(),
             )
         },
@@ -93,6 +99,7 @@ fun AppScreen(
                 state = state.filePreview,
                 onSaveFile = { onAction(AppAction.SavePreviewFile) },
                 onOverwriteFile = { onAction(AppAction.OverwritePreviewFile) },
+                onDeleteFile = { onAction(AppAction.DeletePreviewFile) },
                 modifier = Modifier.fillMaxSize(),
             )
         },
@@ -120,7 +127,7 @@ private fun AppScreenPreview() {
                 selectedAppIndex = 0,
             ),
         onAction = {},
-        splitterState = rememberSplitPaneState(initialPositionPercentage = 0.25f),
-        rightSplitterState = rememberSplitPaneState(initialPositionPercentage = 0.7f),
+        splitterState = rememberSplitPaneState(initialPositionPercentage = 0.1f),
+        rightSplitterState = rememberSplitPaneState(initialPositionPercentage = 0.8f),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/AppStateHolder.kt
@@ -60,8 +60,10 @@ class AppStateHolder(
                 is AppAction.DeleteAppFileNode -> reduceDeleteAppFileNode(uiAction.directory, uiAction.entry)
                 is AppAction.RefreshAppFileNode -> reduceRefreshAppFileNode(uiAction.directory, uiAction.entry)
                 is AppAction.RenameAppFileNode -> reduceRenameAppFileNode(uiAction.directory, uiAction.entry)
+                is AppAction.CreateAppDirectoryNode -> reduceCreateAppDirectoryNode(uiAction.directory, uiAction.parent)
                 AppAction.SavePreviewFile -> reduceSavePreviewFile()
                 AppAction.OverwritePreviewFile -> reduceOverwritePreviewFile()
+                AppAction.DeletePreviewFile -> reduceDeletePreviewFile()
             }
         }
     }
@@ -115,8 +117,46 @@ class AppStateHolder(
         }
     }
 
-    private fun AppFileEntry?.replaceIfSamePath(entry: AppFileEntry): AppFileEntry? =
-        if (this?.path == entry.path) entry else this
+    private suspend fun reduceDeletePreviewFile() {
+        val device = currentState.selectedDevice ?: return
+        val entry = currentState.filePreview.entry as? AppFileEntry.File ?: return
+        if (currentState.filePreview.isDeleting) return
+        if (!confirmDeleteAppFile(entry)) return
+
+        update {
+            copy(
+                filePreview =
+                    filePreview.copy(
+                        isDeleting = true,
+                        errorMessage = null,
+                    ),
+            )
+        }
+
+        val result = installedAppRepository.deleteAppFile(device, entry)
+        if (result.isOk) {
+            reloadCurrentAppFileTrees()
+            update {
+                copy(
+                    selectedDataFile = selectedDataFile?.takeUnless { it.path.isSameOrChildPath(entry.path) },
+                    selectedSdCardDataFile = selectedSdCardDataFile?.takeUnless { it.path.isSameOrChildPath(entry.path) },
+                    filePreview = AppFilePreviewState(),
+                )
+            }
+        } else {
+            update {
+                copy(
+                    filePreview =
+                        filePreview.copy(
+                            isDeleting = false,
+                            errorMessage = result.error.message ?: "Failed to delete file",
+                        ),
+                )
+            }
+        }
+    }
+
+    private fun AppFileEntry?.replaceIfSamePath(entry: AppFileEntry): AppFileEntry? = if (this?.path == entry.path) entry else this
 
     private suspend fun reduceUploadAppFileNode(
         directory: AppDataDirectory,
@@ -145,6 +185,26 @@ class AppStateHolder(
             }
         } else {
             showAppFileOperationError(Language.upload, result.error)
+        }
+    }
+
+    private suspend fun reduceCreateAppDirectoryNode(
+        directory: AppDataDirectory,
+        parentEntry: AppFileEntry.Directory,
+    ) {
+        val device = currentState.selectedDevice ?: return
+        val app = currentState.selectedApp ?: return
+        val directoryName = inputAppDirectoryName() ?: return
+
+        val result = installedAppRepository.createAppDirectory(device, parentEntry, directoryName)
+        if (result.isOk) {
+            if (parentEntry.path.trimEnd('/') == app.rootPath(directory).trimEnd('/')) {
+                refreshCurrentAppFileTree(directory)
+            } else {
+                refreshAppFileTreeDirectory(directory, parentEntry, expand = true)
+            }
+        } else {
+            showAppFileOperationError(Language.createDirectory, result.error)
         }
     }
 
@@ -465,6 +525,47 @@ class AppStateHolder(
                                 parent,
                                 "Name cannot contain /",
                                 Language.rename,
+                                JOptionPane.ERROR_MESSAGE,
+                            )
+                        }
+                        else -> {
+                            selectedName = name
+                            isSelecting = false
+                        }
+                    }
+                }
+            }
+            selectedName
+        }
+
+    private suspend fun inputAppDirectoryName(): String? =
+        withContext<String?>(Dispatchers.Swing) {
+            val parent = KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
+            var selectedName: String? = null
+            var isSelecting = true
+            while (isSelecting) {
+                val input =
+                    JOptionPane.showInputDialog(
+                        parent,
+                        Language.createDirectory,
+                        Language.createDirectory,
+                        JOptionPane.PLAIN_MESSAGE,
+                        null,
+                        null,
+                        "new_directory",
+                    ) as? String
+
+                if (input == null) {
+                    isSelecting = false
+                } else {
+                    val name = input.trim()
+                    when {
+                        name.isBlank() -> isSelecting = false
+                        name.contains("/") -> {
+                            JOptionPane.showMessageDialog(
+                                parent,
+                                "Name cannot contain /",
+                                Language.createDirectory,
                                 JOptionPane.ERROR_MESSAGE,
                             )
                         }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppDetailPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppDetailPane.kt
@@ -43,6 +43,8 @@ fun AppDetailPane(
     onRefreshSdCardDataFileNode: (AppFileEntry) -> Unit,
     onRenameDataFileNode: (AppFileEntry) -> Unit,
     onRenameSdCardDataFileNode: (AppFileEntry) -> Unit,
+    onCreateDataFileDirectoryNode: (AppFileEntry.Directory) -> Unit,
+    onCreateSdCardDataFileDirectoryNode: (AppFileEntry.Directory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (app == null) {
@@ -100,6 +102,7 @@ fun AppDetailPane(
                     value = app.dataDir,
                 )
                 AppFileTreeView(
+                    root = app.dataDir.toAppFileRootDirectory(),
                     tree = dataFileTree,
                     selectedFile = selectedDataFile,
                     onSelectNode = onSelectDataFileNode,
@@ -108,6 +111,7 @@ fun AppDetailPane(
                     onDeleteNode = onDeleteDataFileNode,
                     onRefreshNode = onRefreshDataFileNode,
                     onRenameNode = onRenameDataFileNode,
+                    onCreateDirectoryNode = onCreateDataFileDirectoryNode,
                 )
             }
 
@@ -117,6 +121,7 @@ fun AppDetailPane(
                     value = app.sdCardDataDir,
                 )
                 AppFileTreeView(
+                    root = app.sdCardDataDir.toAppFileRootDirectory(),
                     tree = sdCardDataFileTree,
                     selectedFile = selectedSdCardDataFile,
                     onSelectNode = onSelectSdCardDataFileNode,
@@ -125,8 +130,19 @@ fun AppDetailPane(
                     onDeleteNode = onDeleteSdCardDataFileNode,
                     onRefreshNode = onRefreshSdCardDataFileNode,
                     onRenameNode = onRenameSdCardDataFileNode,
+                    onCreateDirectoryNode = onCreateSdCardDataFileDirectoryNode,
                 )
             }
         }
     }
 }
+
+private fun String.toAppFileRootDirectory(): AppFileEntry.Directory =
+    AppFileEntry.Directory(
+        name = substringAfterLast('/').ifBlank { this },
+        path = this,
+        permissions = "",
+        size = 0L,
+        date = "",
+        time = "",
+    )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/AppFilePreviewPane.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -38,10 +38,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
-import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Download
+import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Minus
 import com.composables.icons.lucide.Plus
+import com.composables.icons.lucide.Trash2
 import com.composables.icons.lucide.Upload
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.app.AppFilePreview
@@ -59,6 +60,7 @@ fun AppFilePreviewPane(
     state: AppFilePreviewState,
     onSaveFile: () -> Unit,
     onOverwriteFile: () -> Unit,
+    onDeleteFile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxSize()) {
@@ -103,10 +105,13 @@ fun AppFilePreviewPane(
         AppFilePreviewActions(
             canOverwrite = state.entry is AppFileEntry.File && !state.isBusy,
             canSave = state.entry is AppFileEntry.File && !state.isBusy,
+            canDelete = state.entry is AppFileEntry.File && !state.isBusy,
             isOverwriting = state.isOverwriting,
             isSaving = state.isSaving,
+            isDeleting = state.isDeleting,
             onOverwriteFile = onOverwriteFile,
             onSaveFile = onSaveFile,
+            onDeleteFile = onDeleteFile,
             modifier = Modifier.fillMaxWidth(),
         )
     }
@@ -174,10 +179,13 @@ private fun AppFilePreviewMetadata(entry: AppFileEntry) {
 private fun AppFilePreviewActions(
     canOverwrite: Boolean,
     canSave: Boolean,
+    canDelete: Boolean,
     isOverwriting: Boolean,
     isSaving: Boolean,
+    isDeleting: Boolean,
     onOverwriteFile: () -> Unit,
     onSaveFile: () -> Unit,
+    onDeleteFile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -190,6 +198,14 @@ private fun AppFilePreviewActions(
                 bottom = 12.dp,
             ),
     ) {
+        AppFilePreviewActionButton(
+            text = Language.delete,
+            icon = Lucide.Trash2,
+            onClick = onDeleteFile,
+            enabled = canDelete,
+            isLoading = isDeleting,
+            modifier = Modifier.weight(1f),
+        )
         AppFilePreviewActionButton(
             text = Language.upload,
             icon = Lucide.Upload,
@@ -417,9 +433,10 @@ private fun AppFilePreviewPanePreview() {
             ),
         onSaveFile = {},
         onOverwriteFile = {},
+        onDeleteFile = {},
         modifier = Modifier.fillMaxSize(),
     )
 }
 
 private val AppFilePreviewState.isBusy: Boolean
-    get() = isLoading || isSaving || isOverwriting
+    get() = isLoading || isSaving || isOverwriting || isDeleting

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeMessageRow.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeMessageRow.kt
@@ -22,7 +22,10 @@ internal fun AppFileTreeMessageRow(
         text = message,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = modifier.fillMaxWidth().padding(start = (depth * 16).dp, top = 6.dp, bottom = 6.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(start = (depth * 16).dp, top = 6.dp, bottom = 6.dp),
         maxLines = 3,
         overflow = TextOverflow.Ellipsis,
     )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeNode.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeNode.kt
@@ -45,6 +45,7 @@ internal fun AppFileTreeNode(
     onDeleteNode: (AppFileEntry) -> Unit,
     onRefreshNode: (AppFileEntry) -> Unit,
     onRenameNode: (AppFileEntry) -> Unit,
+    onCreateDirectoryNode: (AppFileEntry.Directory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isExpanded = tree.expandedPaths.contains(entry.path)
@@ -62,6 +63,7 @@ internal fun AppFileTreeNode(
                     onDeleteNode = onDeleteNode,
                     onRefreshNode = onRefreshNode,
                     onRenameNode = onRenameNode,
+                    onCreateDirectoryNode = onCreateDirectoryNode,
                 )
             },
         ) {
@@ -154,6 +156,7 @@ internal fun AppFileTreeNode(
                             onDeleteNode = onDeleteNode,
                             onRefreshNode = onRefreshNode,
                             onRenameNode = onRenameNode,
+                            onCreateDirectoryNode = onCreateDirectoryNode,
                         )
                     }
                 }
@@ -168,13 +171,17 @@ private fun appFileTreeNodeContextMenuItems(
     onDeleteNode: (AppFileEntry) -> Unit,
     onRefreshNode: (AppFileEntry) -> Unit,
     onRenameNode: (AppFileEntry) -> Unit,
+    onCreateDirectoryNode: (AppFileEntry.Directory) -> Unit,
 ): List<ContextMenuItem> =
-    listOf(
-        ContextMenuItem(label = Language.upload, onClick = { onUploadNode(entry) }),
-        ContextMenuItem(label = Language.delete, onClick = { onDeleteNode(entry) }),
-        ContextMenuItem(label = Language.tooltipRefresh, onClick = { onRefreshNode(entry) }),
-        ContextMenuItem(label = Language.rename, onClick = { onRenameNode(entry) }),
-    )
+    buildList {
+        add(ContextMenuItem(label = Language.upload, onClick = { onUploadNode(entry) }))
+        if (entry is AppFileEntry.Directory) {
+            add(ContextMenuItem(label = Language.createDirectory, onClick = { onCreateDirectoryNode(entry) }))
+        }
+        add(ContextMenuItem(label = Language.delete, onClick = { onDeleteNode(entry) }))
+        add(ContextMenuItem(label = Language.tooltipRefresh, onClick = { onRefreshNode(entry) }))
+        add(ContextMenuItem(label = Language.rename, onClick = { onRenameNode(entry) }))
+    }
 
 @Preview
 @Composable
@@ -196,6 +203,7 @@ private fun AppFileTreeNodePreview() {
         onDeleteNode = {},
         onRefreshNode = {},
         onRenameNode = {},
+        onCreateDirectoryNode = {},
         modifier = Modifier.width(280.dp).padding(16.dp),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeView.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/component/tree/AppFileTreeView.kt
@@ -1,5 +1,6 @@
 package jp.kaleidot725.adbpad.ui.screen.app.component.tree
 
+import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -10,10 +11,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.language.Language
+import jp.kaleidot725.adbpad.ui.component.menu.ThemedContextMenuArea
 import jp.kaleidot725.adbpad.ui.screen.app.state.AppFileTreeState
 
 @Composable
 fun AppFileTreeView(
+    root: AppFileEntry.Directory,
     tree: AppFileTreeState,
     selectedFile: AppFileEntry?,
     onSelectNode: (AppFileEntry) -> Unit,
@@ -22,13 +25,26 @@ fun AppFileTreeView(
     onDeleteNode: (AppFileEntry) -> Unit,
     onRefreshNode: (AppFileEntry) -> Unit,
     onRenameNode: (AppFileEntry) -> Unit,
+    onCreateDirectoryNode: (AppFileEntry.Directory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
         when {
             tree.isLoading && tree.entries.isEmpty() -> AppFileTreeLoadingRow()
-            tree.errorMessage != null -> AppFileTreeMessageRow(tree.errorMessage.ifBlank { Language.appFileTreeEmpty })
-            tree.entries.isEmpty() -> AppFileTreeMessageRow(Language.appFileTreeEmpty)
+            tree.errorMessage != null -> {
+                AppFileTreeRootMessageRow(
+                    root = root,
+                    message = tree.errorMessage.ifBlank { Language.appFileTreeEmpty },
+                    onCreateDirectoryNode = onCreateDirectoryNode,
+                )
+            }
+            tree.entries.isEmpty() -> {
+                AppFileTreeRootMessageRow(
+                    root = root,
+                    message = Language.appFileTreeEmpty,
+                    onCreateDirectoryNode = onCreateDirectoryNode,
+                )
+            }
             else -> {
                 tree.entries.forEach { entry ->
                     AppFileTreeNode(
@@ -42,6 +58,7 @@ fun AppFileTreeView(
                         onDeleteNode = onDeleteNode,
                         onRefreshNode = onRefreshNode,
                         onRenameNode = onRenameNode,
+                        onCreateDirectoryNode = onCreateDirectoryNode,
                     )
                 }
             }
@@ -49,12 +66,33 @@ fun AppFileTreeView(
     }
 }
 
+@Composable
+private fun AppFileTreeRootMessageRow(
+    root: AppFileEntry.Directory,
+    message: String,
+    onCreateDirectoryNode: (AppFileEntry.Directory) -> Unit,
+) {
+    ThemedContextMenuArea(
+        items = {
+            listOf(
+                ContextMenuItem(
+                    label = Language.createDirectory,
+                    onClick = { onCreateDirectoryNode(root) },
+                ),
+            )
+        },
+    ) {
+        AppFileTreeMessageRow(message = message)
+    }
+}
+
 @Preview
 @Composable
 private fun AppFileTreeViewPreview() {
-    val directory = previewAppFileEntries.first()
+    val directory = previewAppFileEntries.first() as AppFileEntry.Directory
 
     AppFileTreeView(
+        root = directory,
         tree =
             AppFileTreeState(
                 entries = previewAppFileEntries,
@@ -68,6 +106,7 @@ private fun AppFileTreeViewPreview() {
         onDeleteNode = {},
         onRefreshNode = {},
         onRenameNode = {},
+        onCreateDirectoryNode = {},
         modifier = Modifier.width(280.dp).padding(16.dp),
     )
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppAction.kt
@@ -1,7 +1,7 @@
 package jp.kaleidot725.adbpad.ui.screen.app.state
 
-import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.app.AppDataDirectory
+import jp.kaleidot725.adbpad.domain.model.app.AppFileEntry
 import jp.kaleidot725.adbpad.domain.model.app.InstalledApp
 import jp.kaleidot725.adbpad.domain.model.sort.SortType
 import jp.kaleidot725.pulse.mvi.PulseAction
@@ -67,7 +67,14 @@ sealed class AppAction : PulseAction {
         val entry: AppFileEntry,
     ) : AppAction()
 
+    data class CreateAppDirectoryNode(
+        val directory: AppDataDirectory,
+        val parent: AppFileEntry.Directory,
+    ) : AppAction()
+
     data object SavePreviewFile : AppAction()
 
     data object OverwritePreviewFile : AppAction()
+
+    data object DeletePreviewFile : AppAction()
 }

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppState.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/app/state/AppState.kt
@@ -77,5 +77,6 @@ data class AppFilePreviewState(
     val isLoading: Boolean = false,
     val isSaving: Boolean = false,
     val isOverwriting: Boolean = false,
+    val isDeleting: Boolean = false,
     val errorMessage: String? = null,
 )

--- a/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainScreen.kt
+++ b/main/kotlin/jp/kaleidot725/adbpad/ui/screen/main/MainScreen.kt
@@ -259,11 +259,11 @@ private fun App(
         )
     val appSplitPaneState =
         rememberSplitPaneState(
-            initialPositionPercentage = 0.25f,
+            initialPositionPercentage = 0.1f,
         )
     val appRightSplitPaneState =
         rememberSplitPaneState(
-            initialPositionPercentage = 0.7f,
+            initialPositionPercentage = 0.8f,
         )
 
     Crossfade(state.language) {


### PR DESCRIPTION
## Summary
- Rebase this PR onto origin/main so the AppFile tree right-click context menus remain available
- Use run-as for /data/data/<package> file tree listing, preview, download, upload/overwrite, delete, and rename operations
- Keep Adam CompatListFileRequest for non-private paths so sdcard browsing still uses sync v2 when available
- Keep app file path and ls/sync entry conversion in InstalledAppRepositoryImpl using the same toAppFileEntries-style conversion flow as before
- Add repository file-conversion and file-operation tests for /data/data paths, sdcard passthrough, run-as ls output, shell quoting, temp filename sanitizing, and mkdir command generation
- Add a delete action to the app file preview pane and clear/reload file tree state after deletion
- Add a Create directory context menu action for directory nodes and empty/error AppFile root rows, so a missing sdcard app root can create directories with mkdir -p instead of relying on refresh
- Align the AppFile left and right pane splitter initial positions with the other three-pane screens

## Notes
- run-as only works for debuggable packages; release/non-debuggable app private data remains inaccessible by Android/ADB design.
- Private file download uses shell v2 so binary contents are not corrupted by shell v1 exit-code parsing.
- ./gradlew test is not available in this Gradle project; use ./gradlew jvmTest for JVM tests.

## Verification
- ./gradlew :core:data:ktlintCheck
- ./gradlew :core:data:jvmTest
- ./gradlew runKtlintCheckOverJvmMainSourceSet
- ./gradlew compileKotlinJvm
- ./gradlew jvmTest
- ./gradlew ktlintCheck fails on existing ktlint violations in unrelated main-source files.